### PR TITLE
fix: client replace not taking effect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "fit-launcher",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fit-launcher",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@fontsource-variable/lexend": "^5.1.1",
         "@fontsource-variable/mulish": "^5.1.0",
         "@fontsource-variable/overpass": "^5.1.1",
         "@fontsource/bai-jamjuree": "^5.2.6",
-        "@solid-primitives/i18n": "^2.1.1",
-        "@solid-primitives/storage": "^4.2.1",
-        "@solid-primitives/workers": "^0.3.0",
+        "@solid-primitives/i18n": "2.2.1",
+        "@solid-primitives/storage": "4.3.3",
+        "@solid-primitives/workers": "0.4.2",
         "@solidjs/router": "^0.14.1",
         "@tailwindcss/vite": "^4.1.10",
         "@tanstack/solid-virtual": "^3.0.4",
@@ -756,21 +756,21 @@
       ]
     },
     "node_modules/@solid-primitives/i18n": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@solid-primitives/i18n/-/i18n-2.1.1.tgz",
-      "integrity": "sha512-1p9B8hveu+gzFRWfXcRtdzzEdr7gw3c8uLXm+2bU33JHgiI8kYJsWvG128sE6vU1ZtYGPrGq980Jd6hxYupyZQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/i18n/-/i18n-2.2.1.tgz",
+      "integrity": "sha512-TnTnE2Ku11MGYZ1JzhJ8pYscwg1fr9MteoYxPwsfxWfh9Jp5K7RRJncJn9BhOHvNLwROjqOHZ46PT7sPHqbcXw==",
       "license": "MIT",
       "peerDependencies": {
         "solid-js": "^1.6.12"
       }
     },
     "node_modules/@solid-primitives/storage": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@solid-primitives/storage/-/storage-4.2.1.tgz",
-      "integrity": "sha512-1XUJeaSlizH9Eam/+IbIpslHEnggJMNZXzfsr06AlbG6tJtQENMu0+94ZIvooxt4Cyw46wPzcnHYbSK7LzoQAA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/storage/-/storage-4.3.3.tgz",
+      "integrity": "sha512-ACbNwMZ1s8VAvld6EUXkDkX/US3IhtlPLxg6+B2s9MwNUugwdd51I98LPEaHrdLpqPmyzqgoJe0TxEFlf3Dqrw==",
       "license": "MIT",
       "dependencies": {
-        "@solid-primitives/utils": "^6.2.3"
+        "@solid-primitives/utils": "^6.3.2"
       },
       "peerDependencies": {
         "@tauri-apps/plugin-store": "*",
@@ -786,18 +786,18 @@
       }
     },
     "node_modules/@solid-primitives/utils": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@solid-primitives/utils/-/utils-6.2.3.tgz",
-      "integrity": "sha512-CqAwKb2T5Vi72+rhebSsqNZ9o67buYRdEJrIFzRXz3U59QqezuuxPsyzTSVCacwS5Pf109VRsgCJQoxKRoECZQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/utils/-/utils-6.3.2.tgz",
+      "integrity": "sha512-hZ/M/qr25QOCcwDPOHtGjxTD8w2mNyVAYvcfgwzBHq2RwNqHNdDNsMZYap20+ruRwW4A3Cdkczyoz0TSxLCAPQ==",
       "license": "MIT",
       "peerDependencies": {
         "solid-js": "^1.6.12"
       }
     },
     "node_modules/@solid-primitives/workers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@solid-primitives/workers/-/workers-0.3.0.tgz",
-      "integrity": "sha512-NdfdHHNn4ut6zWoL/xSAZbIuzdrefwc2jin9Oaa/bI1o1QDKdOBQpR07ig7CzpiVdctyeSk6iE8ab6gnZVSSzQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/workers/-/workers-0.4.2.tgz",
+      "integrity": "sha512-zumTsOmqR6pSUPHw0H6DXUprz8mzzAplJg4iRTBSJ290hoIyv/pLE+40yEAScZNwnTkuxhy5tLP9yweOT+T+GA==",
       "license": "MIT",
       "peerDependencies": {
         "solid-js": "^1.6.12"

--- a/src-tauri/local-crates/fit-launcher-config/src/client/cookies/mod.rs
+++ b/src-tauri/local-crates/fit-launcher-config/src/client/cookies/mod.rs
@@ -56,19 +56,12 @@ impl Cookies {
             .join(";")
     }
 
-    pub fn save_local(cookies: &Vec<Cookie>) -> Result<(), Error> {
-        let path = Self::default_path();
-        let json = serde_json::to_string_pretty(&cookies)?;
-        std::fs::write(path, json)?;
-        Ok(())
-    }
-
     pub fn save(&self) -> Result<(), Error> {
         let path = Self::default_path();
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(path, serde_json::to_vec(self)?)?;
+        std::fs::write(path, serde_json::to_vec_pretty(self)?)?;
         Ok(())
     }
 }

--- a/src-tauri/local-crates/fit-launcher-ddl/src/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-ddl/src/commands.rs
@@ -18,7 +18,14 @@ pub async fn extract_fuckingfast_ddl(fuckingfast_links: Vec<String>) -> Vec<Dire
         // download raw HTML
         .map(|link| -> HtmlDownloadFuture {
             Box::pin(async move {
-                let text = CUSTOM_DNS_CLIENT.get(&link).send().await?.text().await?;
+                let text = CUSTOM_DNS_CLIENT
+                    .read()
+                    .await
+                    .get(&link)
+                    .send()
+                    .await?
+                    .text()
+                    .await?;
                 let filename = link.split_once('#').unwrap_or_default().1.to_string();
                 Ok::<(String, String), reqwest::Error>((text, filename))
             })

--- a/src-tauri/local-crates/fit-launcher-ddl/src/functions.rs
+++ b/src-tauri/local-crates/fit-launcher-ddl/src/functions.rs
@@ -4,6 +4,8 @@ use fit_launcher_scraping::errors::ScrapingError;
 
 pub(crate) async fn get_all_download_links(url: String) -> Result<Vec<String>, Box<ScrapingError>> {
     let response = CUSTOM_DNS_CLIENT
+        .read()
+        .await
         .get(&url)
         .send()
         .await

--- a/src-tauri/local-crates/fit-launcher-scraping/src/discovery.rs
+++ b/src-tauri/local-crates/fit-launcher-scraping/src/discovery.rs
@@ -29,6 +29,8 @@ macro_rules! sel {
 
 async fn head_ok(url: &str) -> bool {
     CUSTOM_DNS_CLIENT
+        .read()
+        .await
         .head(url)
         .send()
         .await

--- a/src-tauri/local-crates/fit-launcher-scraping/src/global/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-scraping/src/global/commands.rs
@@ -116,10 +116,16 @@ pub async fn get_singular_game_info(
         }
     }
 
-    let response = CUSTOM_DNS_CLIENT.get(&url).send().await.map_err(|e| {
-        error!("Failed to fetch URL: {}", e);
-        ScrapingError::HttpStatusCodeError(e.to_string())
-    })?;
+    let response = CUSTOM_DNS_CLIENT
+        .read()
+        .await
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to fetch URL: {}", e);
+            ScrapingError::HttpStatusCodeError(e.to_string())
+        })?;
 
     let body = response.text().await.map_err(|e| {
         error!("Failed to read response body: {}", e);

--- a/src-tauri/local-crates/fit-launcher-scraping/src/global/functions/helper.rs
+++ b/src-tauri/local-crates/fit-launcher-scraping/src/global/functions/helper.rs
@@ -113,6 +113,8 @@ pub async fn find_preview_image(article: ElementRef<'_>) -> Option<String> {
 
 async fn check_url_status(url: &str) -> bool {
     CUSTOM_DNS_CLIENT
+        .read()
+        .await
         .head(url)
         .header(RANGE, "bytes=0-8")
         .send()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,7 +14,6 @@ use fit_launcher_scraping::discovery::get_100_games_unordered;
 use fit_launcher_scraping::get_sitemaps_website;
 use fit_launcher_scraping::global::functions::run_all_scrapers;
 use fit_launcher_torrent::LibrqbitSession;
-use fit_launcher_torrent::functions::ARIA2_DAEMON;
 use fit_launcher_torrent::functions::TorrentSession;
 use lru::LruCache;
 use serde_json::Value;

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -30,7 +30,13 @@ pub struct Payload {
 
 /// Helper function.
 async fn check_url_status(url: &str) -> anyhow::Result<bool> {
-    let response = CUSTOM_DNS_CLIENT.head(url).send().await.unwrap();
+    let response = CUSTOM_DNS_CLIENT
+        .read()
+        .await
+        .head(url)
+        .send()
+        .await
+        .unwrap();
     Ok(response.status().is_success())
 }
 
@@ -81,9 +87,7 @@ async fn fetch_image_links(body: &str) -> anyhow::Result<Vec<String>> {
     let tasks: Vec<_> = initial_images
         .into_iter()
         .map(|img_link| {
-            tokio::task::spawn(async move {
-                (process_image_link(img_link).await).ok()
-            })
+            tokio::task::spawn(async move { (process_image_link(img_link).await).ok() })
         })
         .collect();
 
@@ -105,7 +109,14 @@ async fn scrape_image_srcs(url: &str) -> Result<Vec<String>> {
         return Err(anyhow::anyhow!("Cancelled the Event..."));
     }
 
-    let body = CUSTOM_DNS_CLIENT.get(url).send().await?.text().await?;
+    let body = CUSTOM_DNS_CLIENT
+        .read()
+        .await
+        .get(url)
+        .send()
+        .await?
+        .text()
+        .await?;
     let images = fetch_image_links(&body).await?;
 
     Ok(images)
@@ -177,11 +188,12 @@ async fn merge_cache_from_file(
     cache: &mut LruCache<String, Vec<String>>,
 ) -> Result<()> {
     if let Ok(data) = tokio::fs::read_to_string(cache_file_path).await
-        && let Ok(loaded_cache) = serde_json::from_str::<HashMap<String, Vec<String>>>(&data) {
-            for (key, value) in loaded_cache {
-                cache.put(key, value);
-            }
+        && let Ok(loaded_cache) = serde_json::from_str::<HashMap<String, Vec<String>>>(&data)
+    {
+        for (key, value) in loaded_cache {
+            cache.put(key, value);
         }
+    }
     Ok(())
 }
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -5,17 +5,95 @@
 
 
 export const commands = {
-async getNewlyAddedGames() : Promise<Result<Game[], ScrapingError>> {
+async aria2GetListStopped() : Promise<Result<Status[], Aria2Error>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_newly_added_games") };
+    return { status: "ok", data: await TAURI_INVOKE("aria2_get_list_stopped") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
 },
-async getDownloadSettings() : Promise<Result<FitLauncherConfigV2, TorrentApiError>> {
+/**
+ * start download and receive corresponding gid's.
+ * 
+ * dir: output directory, leave None to use default (user Downloads)
+ */
+async aria2TaskSpawn(directLinks: DirectLink[], dir: string | null) : Promise<Result<AriaTaskResult[], Aria2Error>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_download_settings") };
+    return { status: "ok", data: await TAURI_INVOKE("aria2_task_spawn", { directLinks, dir }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * https://aria2.github.io/manual/en/html/aria2c.html#aria2.getVersion
+ */
+async aria2GetVersion() : Promise<Result<Version, Aria2Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("aria2_get_version") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async removeCollection(collectionName: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("remove_collection", { collectionName }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async runAutomateSetupInstall(path: string) : Promise<Result<null, TorrentApiError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("run_automate_setup_install", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async extractGame(dir: string) : Promise<Result<null, ExtractError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("extract_game", { dir }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async closeSplashscreen() : Promise<void> {
+    await TAURI_INVOKE("close_splashscreen");
+},
+async getInstallationSettings() : Promise<InstallationSettings> {
+    return await TAURI_INVOKE("get_installation_settings");
+},
+async updateDownloadedGameExecutableInfo(gameTitle: string, executableInfo: ExecutableInfo) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("update_downloaded_game_executable_info", { gameTitle, executableInfo }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async listTorrentFiles(magnet: string) : Promise<Result<FileInfo[], TorrentApiError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_torrent_files", { magnet }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getSingularGameInfo(gameLink: string) : Promise<Result<null, ScrapingError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_singular_game_info", { gameLink }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async decryptTorrentFromPaste(pasteLink: string) : Promise<Result<number[], Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("decrypt_torrent_from_paste", { pasteLink }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -24,6 +102,75 @@ async getDownloadSettings() : Promise<Result<FitLauncherConfigV2, TorrentApiErro
 async changeDnsSettings(settings: FitLauncherDnsConfig) : Promise<Result<null, SettingsConfigurationError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_dns_settings", { settings }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * https://aria2.github.io/manual/en/html/aria2c.html#aria2.unpause
+ */
+async aria2Resume(gid: string) : Promise<Result<null, Aria2Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("aria2_resume", { gid }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * `selected_files`: list of torrent metadata files index
+ * when left empty, does nothing.
+ */
+async aria2StartTorrent(torrent: number[], dir: string | null, selectedFiles: number[]) : Promise<Result<string, Aria2Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("aria2_start_torrent", { torrent, dir, selectedFiles }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async importCookies(cookies: Cookies) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("import_cookies", { cookies }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getRecentlyUpdatedGamesPath() : Promise<string> {
+    return await TAURI_INVOKE("get_recently_updated_games_path");
+},
+async resetDnsSettings() : Promise<Result<null, SettingsConfigurationError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("reset_dns_settings") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async resetInstallationSettings() : Promise<Result<null, SettingsConfigurationError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("reset_installation_settings") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async magnetToFile(magnet: string) : Promise<Result<number[], TorrentApiError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("magnet_to_file", { magnet }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * https://aria2.github.io/manual/en/html/aria2c.html#aria2.pause
+ */
+async aria2Pause(gid: string) : Promise<Result<null, Aria2Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("aria2_pause", { gid }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -40,70 +187,16 @@ async aria2PauseAll() : Promise<Result<null, Aria2Error>> {
     else return { status: "error", error: e  as any };
 }
 },
-async removeDownloadedGame(gameTitle: string) : Promise<Result<null, string>> {
+async aria2GetListWaiting() : Promise<Result<Status[], Aria2Error>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("remove_downloaded_game", { gameTitle }) };
+    return { status: "ok", data: await TAURI_INVOKE("aria2_get_list_waiting") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
 },
-async resetGamehubSettings() : Promise<Result<null, SettingsConfigurationError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("reset_gamehub_settings") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async resetDnsSettings() : Promise<Result<null, SettingsConfigurationError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("reset_dns_settings") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * https://aria2.github.io/manual/en/html/aria2c.html#aria2.unpauseAll
- */
-async aria2ResumeAll() : Promise<Result<null, Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_resume_all") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getDnsSettings() : Promise<FitLauncherDnsConfig> {
-    return await TAURI_INVOKE("get_dns_settings");
-},
-/**
- * https://aria2.github.io/manual/en/html/aria2c.html#aria2.remove
- */
-async aria2Remove(gid: string) : Promise<Result<null, Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_remove", { gid }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getPopularGames() : Promise<Result<Game[], ScrapingError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("get_popular_games") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Start an executable using tauri::command
- * 
- * Do not worry about using String, since the path will always be obtained by dialog through Tauri thus making it always corret for the OS.
- */
-async startExecutable(path: string) : Promise<void> {
-    await TAURI_INVOKE("start_executable", { path });
+async getDiscoveryJsonPath() : Promise<string> {
+    return await TAURI_INVOKE("get_discovery_json_path");
 },
 /**
  * get total completed bytes
@@ -116,9 +209,59 @@ async aria2TaskProgress(tasks: AriaTask[]) : Promise<Result<AriaTaskProgress, Ar
     else return { status: "error", error: e  as any };
 }
 },
-async addGameToCollection(collectionName: string, game: Game) : Promise<Result<null, string>> {
+async getDnsSettings() : Promise<FitLauncherDnsConfig> {
+    return await TAURI_INVOKE("get_dns_settings");
+},
+/**
+ * json_path: path to a json file, in the form like:
+ * 
+ * ```json
+ * [
+ * {
+ * "name": "xxx",
+ * "value": "xxx"
+ * },
+ * {
+ * "name": "xxx",
+ * "value": "xxx"
+ * }
+ * ]
+ * ```
+ * 
+ * Extra fields are allowed.
+ * 
+ * Also, to make effect, an restart is required.
+ */
+async importCookiesFile(jsonPath: string) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("add_game_to_collection", { collectionName, game }) };
+    return { status: "ok", data: await TAURI_INVOKE("import_cookies_file", { jsonPath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getDnsSettingsPath() : Promise<string> {
+    return await TAURI_INVOKE("get_dns_settings_path");
+},
+async removeDownloadedGame(gameTitle: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("remove_downloaded_game", { gameTitle }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async changeInstallationSettings(settings: InstallationSettings) : Promise<Result<null, SettingsConfigurationError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_installation_settings", { settings }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aria2GlobalStat() : Promise<Result<GlobalStat, Aria2Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("aria2_global_stat") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -127,9 +270,62 @@ async addGameToCollection(collectionName: string, game: Game) : Promise<Result<n
 async getGamehubSettingsPath() : Promise<string> {
     return await TAURI_INVOKE("get_gamehub_settings_path");
 },
-async getSingularGameLocal(url: string) : Promise<Result<Game, ScrapingError>> {
+async resetGamehubSettings() : Promise<Result<null, SettingsConfigurationError>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_singular_game_local", { url }) };
+    return { status: "ok", data: await TAURI_INVOKE("reset_gamehub_settings") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getPopularGamesPath() : Promise<string> {
+    return await TAURI_INVOKE("get_popular_games_path");
+},
+async extractFuckingfastDdl(fuckingfastLinks: string[]) : Promise<DirectLink[]> {
+    return await TAURI_INVOKE("extract_fuckingfast_ddl", { fuckingfastLinks });
+},
+async getCollectionList() : Promise<GameCollection[]> {
+    return await TAURI_INVOKE("get_collection_list");
+},
+async getDownloadedGames() : Promise<DownloadedGame[]> {
+    return await TAURI_INVOKE("get_downloaded_games");
+},
+async addGameToCollection(collectionName: string, game: Game) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("add_game_to_collection", { collectionName, game }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async createCollection(collectionName: string, games: Game[] | null) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("create_collection", { collectionName, games }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async executableInfoDiscovery(pathToExe: string, pathToFolder: string) : Promise<ExecutableInfo | null> {
+    return await TAURI_INVOKE("executable_info_discovery", { pathToExe, pathToFolder });
+},
+async getDiscoveryMetaPath() : Promise<string> {
+    return await TAURI_INVOKE("get_discovery_meta_path");
+},
+async getGamehubSettings() : Promise<GamehubSettings> {
+    return await TAURI_INVOKE("get_gamehub_settings");
+},
+async clearAllCache() : Promise<Result<null, SettingsConfigurationError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clear_all_cache") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getDownloadSettings() : Promise<Result<FitLauncherConfigV2, TorrentApiError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_download_settings") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -138,77 +334,50 @@ async getSingularGameLocal(url: string) : Promise<Result<Game, ScrapingError>> {
 async getNewlyAddedGamesPath() : Promise<string> {
     return await TAURI_INVOKE("get_newly_added_games_path");
 },
+async transformLegacyDownload(legacyItems: LegacyDownloadedGame[]) : Promise<DownloadedGame[]> {
+    return await TAURI_INVOKE("transform_legacy_download", { legacyItems });
+},
+async removeGameFromCollection(gameTitle: string, collectionName: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("remove_game_from_collection", { gameTitle, collectionName }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * https://aria2.github.io/manual/en/html/aria2c.html#aria2.remove
+ */
+async aria2Remove(gid: string) : Promise<Result<null, Aria2Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("aria2_remove", { gid }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async changeDownloadSettings(config: FitLauncherConfigV2) : Promise<Result<null, TorrentApiError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_download_settings", { config }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async deleteGameFolderRecursively(folderPath: string) : Promise<Result<null, TorrentApiError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("delete_game_folder_recursively", { folderPath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getDatahosterLinks(gameLink: string, datahosterName: string) : Promise<string[] | null> {
+    return await TAURI_INVOKE("get_datahoster_links", { gameLink, datahosterName });
+},
 async removeGameToDownload(gameTitle: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("remove_game_to_download", { gameTitle }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async listTorrentFiles(magnet: string) : Promise<Result<FileInfo[], TorrentApiError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("list_torrent_files", { magnet }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async runAutomateSetupInstall(path: string) : Promise<Result<null, TorrentApiError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("run_automate_setup_install", { path }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async hashUrl(url: string) : Promise<string> {
-    return await TAURI_INVOKE("hash_url", { url });
-},
-async resetInstallationSettings() : Promise<Result<null, SettingsConfigurationError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("reset_installation_settings") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getTorrentHash(torrent: number[]) : Promise<Result<string, string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("get_torrent_hash", { torrent }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getGamehubSettings() : Promise<GamehubSettings> {
-    return await TAURI_INVOKE("get_gamehub_settings");
-},
-async getInstallationSettingsPath() : Promise<string> {
-    return await TAURI_INVOKE("get_installation_settings_path");
-},
-async removeCollection(collectionName: string) : Promise<Result<null, string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("remove_collection", { collectionName }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async magnetToFile(magnet: string) : Promise<Result<number[], TorrentApiError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("magnet_to_file", { magnet }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getDownloadedGames() : Promise<DownloadedGame[]> {
-    return await TAURI_INVOKE("get_downloaded_games");
-},
-async decryptTorrentFromPaste(pasteLink: string) : Promise<Result<number[], Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("decrypt_torrent_from_paste", { pasteLink }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -242,198 +411,25 @@ async aria2StartDownload(url: string[], dir: string | null, filename: string | n
     else return { status: "error", error: e  as any };
 }
 },
-async openLogsDirectory() : Promise<Result<null, string>> {
+async getSingularGameLocal(url: string) : Promise<Result<Game, ScrapingError>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("open_logs_directory") };
+    return { status: "ok", data: await TAURI_INVOKE("get_singular_game_local", { url }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
 },
-async updateDownloadedGameExecutableInfo(gameTitle: string, executableInfo: ExecutableInfo) : Promise<Result<null, string>> {
+async getNewlyAddedGames() : Promise<Result<Game[], ScrapingError>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("update_downloaded_game_executable_info", { gameTitle, executableInfo }) };
+    return { status: "ok", data: await TAURI_INVOKE("get_newly_added_games") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
 },
-async clearAllCache() : Promise<Result<null, SettingsConfigurationError>> {
+async configChangeOnlyPath(downloadPath: string) : Promise<Result<null, TorrentApiError>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("clear_all_cache") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async importCookies(cookies: Cookies) : Promise<Result<null, string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("import_cookies", { cookies }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * https://aria2.github.io/manual/en/html/aria2c.html#aria2.unpause
- */
-async aria2Resume(gid: string) : Promise<Result<null, Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_resume", { gid }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getPopularGamesPath() : Promise<string> {
-    return await TAURI_INVOKE("get_popular_games_path");
-},
-async getSingularGameInfo(gameLink: string) : Promise<Result<null, ScrapingError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("get_singular_game_info", { gameLink }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async executableInfoDiscovery(pathToExe: string, pathToFolder: string) : Promise<ExecutableInfo | null> {
-    return await TAURI_INVOKE("executable_info_discovery", { pathToExe, pathToFolder });
-},
-async changeInstallationSettings(settings: InstallationSettings) : Promise<Result<null, SettingsConfigurationError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("change_installation_settings", { settings }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * json_path: path to a json file, in the form like:
- * 
- * ```json
- * [
- * {
- * "name": "xxx",
- * "value": "xxx"
- * },
- * {
- * "name": "xxx",
- * "value": "xxx"
- * }
- * ]
- * ```
- * 
- * Extra fields are allowed.
- * 
- * Also, to make effect, an restart is required.
- */
-async importCookiesFile(jsonPath: string) : Promise<Result<null, string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("import_cookies_file", { jsonPath }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getDiscoveryMetaPath() : Promise<string> {
-    return await TAURI_INVOKE("get_discovery_meta_path");
-},
-async closeSplashscreen() : Promise<void> {
-    await TAURI_INVOKE("close_splashscreen");
-},
-async aria2GetListWaiting() : Promise<Result<Status[], Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_get_list_waiting") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async extractFuckingfastDdl(fuckingfastLinks: string[]) : Promise<DirectLink[]> {
-    return await TAURI_INVOKE("extract_fuckingfast_ddl", { fuckingfastLinks });
-},
-async aria2GetListStopped() : Promise<Result<Status[], Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_get_list_stopped") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async createCollection(collectionName: string, games: Game[] | null) : Promise<Result<null, string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("create_collection", { collectionName, games }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getInstallationSettings() : Promise<InstallationSettings> {
-    return await TAURI_INVOKE("get_installation_settings");
-},
-async getCollectionList() : Promise<GameCollection[]> {
-    return await TAURI_INVOKE("get_collection_list");
-},
-async getDiscoveryJsonPath() : Promise<string> {
-    return await TAURI_INVOKE("get_discovery_json_path");
-},
-async aria2GlobalStat() : Promise<Result<GlobalStat, Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_global_stat") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getRecentlyUpdatedGamesPath() : Promise<string> {
-    return await TAURI_INVOKE("get_recently_updated_games_path");
-},
-async deleteGameFolderRecursively(folderPath: string) : Promise<Result<null, TorrentApiError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("delete_game_folder_recursively", { folderPath }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async removeGameFromCollection(gameTitle: string, collectionName: string) : Promise<Result<null, string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("remove_game_from_collection", { gameTitle, collectionName }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getGamesImages(gameLink: string) : Promise<Result<string[], CustomError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("get_games_images", { gameLink }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async stopGetGamesImages() : Promise<void> {
-    await TAURI_INVOKE("stop_get_games_images");
-},
-async aria2GetListActive() : Promise<Result<Status[], Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_get_list_active") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async changeGamehubSettings(settings: GamehubSettings) : Promise<Result<null, SettingsConfigurationError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("change_gamehub_settings", { settings }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async addDownloadedGame(game: DownloadedGame) : Promise<Result<null, string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("add_downloaded_game", { game }) };
+    return { status: "ok", data: await TAURI_INVOKE("config_change_only_path", { downloadPath }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -450,11 +446,13 @@ async aria2GetStatus(gid: string) : Promise<Result<Status, Aria2Error>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getDnsSettingsPath() : Promise<string> {
-    return await TAURI_INVOKE("get_dns_settings_path");
-},
-async getDatahosterLinks(gameLink: string, datahosterName: string) : Promise<string[] | null> {
-    return await TAURI_INVOKE("get_datahoster_links", { gameLink, datahosterName });
+async getTorrentHash(torrent: number[]) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_torrent_hash", { torrent }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 },
 async checkDominantColorVec(listImages: string[]) : Promise<Result<string[], string>> {
     try {
@@ -464,86 +462,9 @@ async checkDominantColorVec(listImages: string[]) : Promise<Result<string[], str
     else return { status: "error", error: e  as any };
 }
 },
-/**
- * `selected_files`: list of torrent metadata files index
- * when left empty, does nothing.
- */
-async aria2StartTorrent(torrent: number[], dir: string | null, selectedFiles: number[]) : Promise<Result<string, Aria2Error>> {
+async aria2GetListActive() : Promise<Result<Status[], Aria2Error>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_start_torrent", { torrent, dir, selectedFiles }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * https://aria2.github.io/manual/en/html/aria2c.html#aria2.getVersion
- */
-async aria2GetVersion() : Promise<Result<Version, Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_get_version") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getGamesToDownload() : Promise<Game[]> {
-    return await TAURI_INVOKE("get_games_to_download");
-},
-async changeDownloadSettings(config: FitLauncherConfigV2) : Promise<Result<null, TorrentApiError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("change_download_settings", { config }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async configChangeOnlyPath(downloadPath: string) : Promise<Result<null, TorrentApiError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("config_change_only_path", { downloadPath }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async getRecentlyUpdatedGames() : Promise<Result<Game[], ScrapingError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("get_recently_updated_games") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async extractGame(dir: string) : Promise<Result<null, ExtractError>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("extract_game", { dir }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-async transformLegacyDownload(legacyItems: LegacyDownloadedGame[]) : Promise<DownloadedGame[]> {
-    return await TAURI_INVOKE("transform_legacy_download", { legacyItems });
-},
-/**
- * https://aria2.github.io/manual/en/html/aria2c.html#aria2.pause
- */
-async aria2Pause(gid: string) : Promise<Result<null, Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_pause", { gid }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * start download and receive corresponding gid's.
- * 
- * dir: output directory, leave None to use default (user Downloads)
- */
-async aria2TaskSpawn(directLinks: DirectLink[], dir: string | null) : Promise<Result<AriaTaskResult[], Aria2Error>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("aria2_task_spawn", { directLinks, dir }) };
+    return { status: "ok", data: await TAURI_INVOKE("aria2_get_list_active") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -557,9 +478,88 @@ async allowDir(path: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Start an executable using tauri::command
+ * 
+ * Do not worry about using String, since the path will always be obtained by dialog through Tauri thus making it always corret for the OS.
+ */
+async startExecutable(path: string) : Promise<void> {
+    await TAURI_INVOKE("start_executable", { path });
+},
+async getRecentlyUpdatedGames() : Promise<Result<Game[], ScrapingError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_recently_updated_games") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getInstallationSettingsPath() : Promise<string> {
+    return await TAURI_INVOKE("get_installation_settings_path");
+},
+async getGamesImages(gameLink: string) : Promise<Result<string[], CustomError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_games_images", { gameLink }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async openLogsDirectory() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("open_logs_directory") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * https://aria2.github.io/manual/en/html/aria2c.html#aria2.unpauseAll
+ */
+async aria2ResumeAll() : Promise<Result<null, Aria2Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("aria2_resume_all") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async stopGetGamesImages() : Promise<void> {
+    await TAURI_INVOKE("stop_get_games_images");
+},
+async addDownloadedGame(game: DownloadedGame) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("add_downloaded_game", { game }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async hashUrl(url: string) : Promise<string> {
+    return await TAURI_INVOKE("hash_url", { url });
+},
 async getDiscoveryGames() : Promise<Result<DiscoveryGame[], ScrapingError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_discovery_games") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async changeGamehubSettings(settings: GamehubSettings) : Promise<Result<null, SettingsConfigurationError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("change_gamehub_settings", { settings }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getGamesToDownload() : Promise<Game[]> {
+    return await TAURI_INVOKE("get_games_to_download");
+},
+async getPopularGames() : Promise<Result<Game[], ScrapingError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_popular_games") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };


### PR DESCRIPTION
The client clone we used was just repointing a local Arc pointer to another `ClientRef`, thus we did nothing useful, and dropped custom DNS e.g.

This will recreate a Client from scratch (which loads newest cookies), fix the save_local may fail if `cookies` weren't created, e.g.