### PR TITLE
CI: Pin rustc version to make build cache more useful

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm' 
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.91.1
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
Currently, our build cache would become outdated as soon as rust released a new stable toolchain version

Recently, rust publishes new version per at most 14 days, thus our build cache are likely not working

This also depends on how frequent we build and publish early access versions, and has impact on our MSRV limitation