### PR TITLE
fix: re-implement autoClean & fix aria2 renaming

### DIFF
--- a/src-tauri/local-crates/fit-launcher-torrent/src/functions.rs
+++ b/src-tauri/local-crates/fit-launcher-torrent/src/functions.rs
@@ -77,6 +77,9 @@ fn build_aria2_args(
 ) -> Vec<String> {
     let mut a = Vec::<String>::new();
 
+    // Disable file renaming, i.e. always skip existing files
+    a.push("--auto-file-renaming=false".into());
+
     // RPC ------------------------------------------------------------------
     a.push("--enable-rpc".into());
     let rpc_port = rpc_port.clamp(1024, 65535);

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/extraction/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/extraction/commands.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, path::PathBuf};
 
-use fit_launcher_scraping::structs::Game;
 use specta::specta;
 use tokio::task::JoinSet;
 use tracing::info;
@@ -9,9 +8,9 @@ use crate::{auto_installation, errors::ExtractError, extract_archive};
 
 #[tauri::command]
 #[specta]
-pub async fn extract_game(job_path: PathBuf) -> Result<(), ExtractError> {
+pub async fn extract_game(job_path: PathBuf, auto_clean: bool) -> Result<(), ExtractError> {
     let list = job_path.read_dir()?;
-    let mut groups = HashMap::new();
+    let mut groups: HashMap<String, Vec<PathBuf>> = HashMap::new();
     for entry in list.flatten() {
         if entry.metadata()?.is_dir() {
             continue;
@@ -24,45 +23,31 @@ pub async fn extract_game(job_path: PathBuf) -> Result<(), ExtractError> {
             continue;
         }
 
-        let (group, part_num) = {
-            // Case 1: pattern ".part1.N.rar"
-            if let Some((g, p)) = name.split_once(".part1.") {
-                let n = p
-                    .trim_end_matches(".rar")
-                    .parse::<u32>()
-                    .unwrap_or(u32::MAX);
-                (g.to_owned(), n)
-            }
-            // Case 2: pattern ".partN.rar"
-            else if let Some((g, p)) = name.rsplit_once(".part") {
-                let n = p
-                    .trim_end_matches(".rar")
-                    .parse::<u32>()
-                    .unwrap_or(u32::MAX);
-                (g.to_owned(), n)
-            }
-            // Case 3: single file
-            else {
-                (name.to_string(), 0)
-            }
-        };
+        let group = name
+            .split_once(".part")
+            .map(|(group, _)| group)
+            .unwrap_or(&*name);
 
-        groups
-            .entry(group)
-            .and_modify(|(existing_num, _existing_path)| {
-                if part_num < *existing_num {
-                    *existing_num = part_num;
-                }
-            })
-            .or_insert((part_num, entry.path()));
+        groups.entry(group.into()).or_default().push(entry.path());
     }
 
-    for (_group, (_num, path)) in groups {
-        info!("Extracting {path:?} in-place...");
-        extract_archive(&path)?;
+    for (_group, paths) in &groups {
+        let Some(first) = paths.first() else {
+            continue;
+        };
+        info!("Extracting {first:?} in-place...");
+        extract_archive(&first)?;
     }
 
     auto_installation(&job_path).await?;
+
+    if auto_clean {
+        let mut set = JoinSet::new();
+        for rar in groups.into_values().flatten() {
+            set.spawn(tokio::fs::remove_file(rar));
+        }
+        set.join_all().await;
+    }
 
     Ok(())
 }

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/extraction/functions.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/extraction/functions.rs
@@ -4,6 +4,10 @@ use unrar::Archive;
 
 use crate::errors::ExtractError;
 
+/// Find first archive of a rar group, and extract files
+///
+/// DO NOT call this multiple times for the same RAR group
+/// (foo.part*1~N*.rar e.g.), or it will extract files for N times
 pub fn extract_archive(file: &Path) -> Result<(), ExtractError> {
     let target_dir = file.parent().ok_or(ExtractError::NoParentDirectory)?;
 

--- a/src/api/installation/api.ts
+++ b/src/api/installation/api.ts
@@ -40,7 +40,7 @@ export class InstallationApi {
       await GlobalSettingsApi.getInstallationSettings();
 
     if (installationSettings.auto_install) {
-      const result = await commands.extractGame(job.job_path);
+      const result = await commands.extractGame(job.job_path, installationSettings.auto_clean);
 
       if (result.status === "error") {
         const err = result.error;

--- a/src/api/installer/api.ts
+++ b/src/api/installer/api.ts
@@ -46,7 +46,7 @@ class InstallerService {
           );
         }
       } else {
-        result = await commands.extractGame(job.job_path);
+        result = await commands.extractGame(job.job_path, settings.auto_clean);
         if (result.status === "error") {
           const err = result.error;
           if (typeof err === "object" && "InstallationError" in err) {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -594,9 +594,9 @@ async getDiscoveryGames() : Promise<Result<DiscoveryGame[], ScrapingError>> {
     else return { status: "error", error: e  as any };
 }
 },
-async extractGame(jobPath: string) : Promise<Result<null, ExtractError>> {
+async extractGame(jobPath: string, autoClean: boolean) : Promise<Result<null, ExtractError>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("extract_game", { jobPath }) };
+    return { status: "ok", data: await TAURI_INVOKE("extract_game", { jobPath, autoClean }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };


### PR DESCRIPTION
- For aria2, disable auto file renaming, which misled @CarrotRub, resulting a incorrect RAR lookup logic
- For DDL downloads, add auto clean back, this was removed accidentally