### PR TITLE
feat: Add modular debrid services support (Real-Debrid, AllDebrid)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1645,6 +1645,7 @@ dependencies = [
  "fit-launcher-aria2",
  "fit-launcher-config",
  "fit-launcher-ddl",
+ "fit-launcher-debrid",
  "fit-launcher-download-manager",
  "fit-launcher-library",
  "fit-launcher-scraping",
@@ -1746,6 +1747,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fit-launcher-debrid"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "fit-launcher-ddl",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "specta",
+ "tauri",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "fit-launcher-download-manager"
 version = "0.1.0"
 dependencies = [
@@ -1755,6 +1776,7 @@ dependencies = [
  "directories",
  "fit-launcher-aria2",
  "fit-launcher-ddl",
+ "fit-launcher-debrid",
  "fit-launcher-scraping",
  "fit-launcher-torrent",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -98,6 +98,7 @@ fit-launcher-config = { path = "./local-crates/fit-launcher-config" }
 fit-launcher-scraping = { path = "./local-crates/fit-launcher-scraping" }
 fit-launcher-aria2 = { path = "./local-crates/fit-launcher-aria2" }
 fit-launcher-ddl = { path = "./local-crates/fit-launcher-ddl" }
+fit-launcher-debrid = { path = "./local-crates/fit-launcher-debrid" }
 fit-launcher-library = { path = "./local-crates/fit-launcher-library" }
 fit-launcher-download-manager = { path = "./local-crates/fit-launcher-download-manager" }
 
@@ -109,6 +110,7 @@ members = [
     "local-crates/fit-launcher-aria2",
     "local-crates/fit-launcher-config",
     "local-crates/fit-launcher-ddl",
+    "local-crates/fit-launcher-debrid",
     "local-crates/fit-launcher-library",
     "local-crates/fit-launcher-scraping",
     "local-crates/fit-launcher-torrent",
@@ -169,7 +171,7 @@ tracing-appender = "0.2.3"
 tokio = { version = "1.48.0", features = ["full"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
-serde_with = "3.12.0"
+serde_with = { version = "3.12.0", features = ["chrono"] }
 directories = "6.0.0"
 uiautomation = "0.24.1"
 windows = { version = "0.62.2", features = [
@@ -193,6 +195,8 @@ once_cell = "1.21.3"
 rand = { version = "0.9.2", features = ["small_rng"] }
 futures = "0.3.31"
 futures-util = "0.3"
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
 
 # Parsing and scraping
 scraper = "0.24.0"

--- a/src-tauri/local-crates/fit-launcher-debrid/Cargo.toml
+++ b/src-tauri/local-crates/fit-launcher-debrid/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "fit-launcher-debrid"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+# Tauri and Specta
+tauri = { workspace = true }
+specta = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Async
+tokio = { workspace = true }
+futures = { workspace = true }
+async-trait = { workspace = true }
+
+# HTTP client
+reqwest = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Encoding
+base64 = "0.22"
+
+# Time
+chrono = { workspace = true }
+
+# Local crates
+fit-launcher-ddl = { path = "../fit-launcher-ddl" }
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/commands.rs
@@ -1,0 +1,64 @@
+use specta::specta;
+
+use crate::{
+    AllDebridProvider, DebridError, DebridProvider, DebridRegistry, ProviderInfo,
+    RealDebridProvider, SubscriptionInfo,
+};
+
+/// Get the global debrid registry with all available providers
+fn get_registry() -> DebridRegistry {
+    let mut registry = DebridRegistry::new();
+    registry.register(RealDebridProvider::new());
+    registry.register(AllDebridProvider::new());
+    registry
+}
+
+/// List all available debrid providers
+#[tauri::command]
+#[specta]
+pub async fn debrid_list_providers() -> Vec<ProviderInfo> {
+    get_registry().list_providers()
+}
+
+/// Validate an API key for a specific provider
+#[tauri::command]
+#[specta]
+pub async fn debrid_validate_api_key(
+    provider_id: String,
+    api_key: String,
+) -> Result<bool, DebridError> {
+    let registry = get_registry();
+    let provider = registry.get_or_err(&provider_id)?;
+    provider.validate_api_key(&api_key).await
+}
+
+/// Get subscription information for a provider
+#[tauri::command]
+#[specta]
+pub async fn debrid_get_subscription(
+    provider_id: String,
+    api_key: String,
+) -> Result<SubscriptionInfo, DebridError> {
+    let registry = get_registry();
+    let provider = registry.get_or_err(&provider_id)?;
+    provider.get_subscription_info(&api_key).await
+}
+
+/// Check if a magnet is cached (instant available) on a provider
+#[tauri::command]
+#[specta]
+pub async fn debrid_is_cached(
+    provider_id: String,
+    api_key: String,
+    magnet: String,
+) -> Result<bool, DebridError> {
+    let registry = get_registry();
+    let provider = registry.get_or_err(&provider_id)?;
+    provider.is_cached(&api_key, &magnet).await
+}
+
+/// Get the provider for use in download manager
+pub fn get_provider(provider_id: &str) -> Result<std::sync::Arc<dyn DebridProvider>, DebridError> {
+    get_registry().get_or_err(provider_id)
+}
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/config.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/config.rs
@@ -1,0 +1,225 @@
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+use tracing::{debug, error};
+
+use crate::DebridError;
+
+const STORE_FILE: &str = "debrid_config.json";
+
+/// Stored credentials for a debrid provider
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct StoredCredentials {
+    /// Provider ID
+    pub provider_id: String,
+    /// Encoded API key (base64 for basic obfuscation)
+    pub api_key_encoded: String,
+    /// Whether this provider is enabled
+    pub enabled: bool,
+}
+
+/// Debrid settings storage
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Default)]
+pub struct DebridStoredSettings {
+    /// Default provider to use
+    pub default_provider: Option<String>,
+    /// Whether to auto-fallback to torrent on debrid failure
+    pub auto_fallback: bool,
+}
+
+/// All stored debrid data
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct DebridStoreData {
+    credentials: Vec<StoredCredentials>,
+    settings: DebridStoredSettings,
+}
+
+/// Encode API key for storage (basic obfuscation, not encryption)
+fn encode_api_key(key: &str) -> String {
+    use std::io::Write;
+    let mut encoder = base64::write::EncoderStringWriter::new(&base64::engine::general_purpose::STANDARD);
+    encoder.write_all(key.as_bytes()).unwrap();
+    encoder.into_inner()
+}
+
+/// Decode API key from storage
+fn decode_api_key(encoded: &str) -> Result<String, DebridError> {
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|e| DebridError::InternalError(format!("Failed to decode API key: {}", e)))?;
+    String::from_utf8(bytes)
+        .map_err(|e| DebridError::InternalError(format!("Invalid UTF-8 in API key: {}", e)))
+}
+
+/// Get the store file path
+fn get_store_path(app: &AppHandle) -> PathBuf {
+    app.path()
+        .app_config_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(STORE_FILE)
+}
+
+/// Load store data from file
+fn load_store_data(app: &AppHandle) -> DebridStoreData {
+    let path = get_store_path(app);
+    if path.exists() {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match serde_json::from_str(&contents) {
+                Ok(data) => return data,
+                Err(e) => error!("Failed to parse debrid config: {}", e),
+            },
+            Err(e) => error!("Failed to read debrid config: {}", e),
+        }
+    }
+    DebridStoreData::default()
+}
+
+/// Save store data to file
+fn save_store_data(app: &AppHandle, data: &DebridStoreData) -> Result<(), DebridError> {
+    let path = get_store_path(app);
+    
+    // Ensure directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| DebridError::InternalError(format!("Failed to create config dir: {}", e)))?;
+    }
+    
+    let contents = serde_json::to_string_pretty(data)
+        .map_err(|e| DebridError::InternalError(format!("Failed to serialize config: {}", e)))?;
+    
+    std::fs::write(&path, contents)
+        .map_err(|e| DebridError::InternalError(format!("Failed to write config: {}", e)))?;
+    
+    debug!("Saved debrid config to {:?}", path);
+    Ok(())
+}
+
+// ============================================================================
+// Tauri Commands for Credentials Management
+// ============================================================================
+
+/// Save credentials for a provider
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_save_credentials(
+    app: AppHandle,
+    provider_id: String,
+    api_key: String,
+    enabled: bool,
+) -> Result<(), DebridError> {
+    let mut data = load_store_data(&app);
+    
+    // Encode the API key
+    let encoded_key = encode_api_key(&api_key);
+    
+    // Find and update or add new credentials
+    if let Some(cred) = data.credentials.iter_mut().find(|c| c.provider_id == provider_id) {
+        cred.api_key_encoded = encoded_key;
+        cred.enabled = enabled;
+    } else {
+        data.credentials.push(StoredCredentials {
+            provider_id,
+            api_key_encoded: encoded_key,
+            enabled,
+        });
+    }
+    
+    save_store_data(&app, &data)
+}
+
+/// Get credentials for a provider
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_get_credentials(
+    app: AppHandle,
+    provider_id: String,
+) -> Result<Option<StoredCredentials>, DebridError> {
+    let data = load_store_data(&app);
+    Ok(data.credentials.into_iter().find(|c| c.provider_id == provider_id))
+}
+
+/// Get the decoded API key for a provider
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_get_api_key(
+    app: AppHandle,
+    provider_id: String,
+) -> Result<Option<String>, DebridError> {
+    let data = load_store_data(&app);
+    if let Some(cred) = data.credentials.iter().find(|c| c.provider_id == provider_id) {
+        let decoded = decode_api_key(&cred.api_key_encoded)?;
+        Ok(Some(decoded))
+    } else {
+        Ok(None)
+    }
+}
+
+/// List all configured providers (those with saved credentials)
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_list_configured_providers(
+    app: AppHandle,
+) -> Result<Vec<StoredCredentials>, DebridError> {
+    let data = load_store_data(&app);
+    // Return credentials but with encoded keys (not decoded for security)
+    Ok(data.credentials)
+}
+
+/// Remove credentials for a provider
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_remove_credentials(
+    app: AppHandle,
+    provider_id: String,
+) -> Result<(), DebridError> {
+    let mut data = load_store_data(&app);
+    data.credentials.retain(|c| c.provider_id != provider_id);
+    save_store_data(&app, &data)
+}
+
+/// Get debrid settings
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_get_settings(
+    app: AppHandle,
+) -> Result<DebridStoredSettings, DebridError> {
+    let data = load_store_data(&app);
+    Ok(data.settings)
+}
+
+/// Save debrid settings
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_save_settings(
+    app: AppHandle,
+    settings: DebridStoredSettings,
+) -> Result<(), DebridError> {
+    let mut data = load_store_data(&app);
+    data.settings = settings;
+    save_store_data(&app, &data)
+}
+
+/// Set the default provider
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_set_default_provider(
+    app: AppHandle,
+    provider_id: Option<String>,
+) -> Result<(), DebridError> {
+    let mut data = load_store_data(&app);
+    data.settings.default_provider = provider_id;
+    save_store_data(&app, &data)
+}
+
+/// Check if any provider is configured and enabled
+#[tauri::command]
+#[specta::specta]
+pub async fn debrid_has_configured_provider(
+    app: AppHandle,
+) -> Result<bool, DebridError> {
+    let data = load_store_data(&app);
+    Ok(data.credentials.iter().any(|c| c.enabled))
+}
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/error.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/error.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use thiserror::Error;
+
+/// Errors that can occur when interacting with debrid services
+#[derive(Debug, Serialize, Deserialize, Type, Error, Clone)]
+pub enum DebridError {
+    /// The provided API key is invalid or malformed
+    #[error("Invalid API key")]
+    InvalidApiKey,
+
+    /// The API key is valid but the subscription has expired
+    #[error("Subscription expired")]
+    SubscriptionExpired,
+
+    /// The user has exceeded their download quota
+    #[error("Download quota exceeded")]
+    QuotaExceeded,
+
+    /// The provided magnet link is not supported by the service
+    #[error("Magnet link not supported by this provider")]
+    MagnetNotSupported,
+
+    /// The torrent conversion timed out
+    #[error("Conversion timeout after {0} seconds")]
+    ConversionTimeout(u64),
+
+    /// The torrent conversion failed on the debrid service
+    #[error("Conversion failed: {0}")]
+    ConversionFailed(String),
+
+    /// Network error while communicating with the API
+    #[error("Network error: {0}")]
+    NetworkError(String),
+
+    /// API returned an error response
+    #[error("API error (code {code}): {message}")]
+    ApiError { code: i32, message: String },
+
+    /// The requested torrent was not found on the debrid service
+    #[error("Torrent not found")]
+    TorrentNotFound,
+
+    /// The provider is not configured or not found
+    #[error("Provider not found: {0}")]
+    ProviderNotFound(String),
+
+    /// Rate limit exceeded
+    #[error("Rate limit exceeded, retry after {0} seconds")]
+    RateLimited(u64),
+
+    /// Generic internal error
+    #[error("Internal error: {0}")]
+    InternalError(String),
+}
+
+impl From<reqwest::Error> for DebridError {
+    fn from(err: reqwest::Error) -> Self {
+        DebridError::NetworkError(err.to_string())
+    }
+}
+
+impl From<serde_json::Error> for DebridError {
+    fn from(err: serde_json::Error) -> Self {
+        DebridError::InternalError(format!("JSON parsing error: {}", err))
+    }
+}
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/lib.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod commands;
+pub mod config;
+pub mod error;
+pub mod providers;
+pub mod registry;
+pub mod types;
+
+pub use commands::*;
+pub use config::*;
+pub use error::*;
+pub use providers::*;
+pub use registry::*;
+pub use types::*;
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/providers/all_debrid.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/providers/all_debrid.rs
@@ -1,0 +1,540 @@
+use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
+use fit_launcher_ddl::DirectLink;
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, error, warn};
+
+use crate::{
+    DebridError, DebridFile, DebridProvider, DebridTorrentInfo, SubscriptionInfo, TorrentStatus,
+    TorrentStatusKind,
+};
+
+const BASE_URL: &str = "https://api.alldebrid.com/v4";
+const AGENT: &str = "FitLauncher";
+
+/// AllDebrid API provider implementation
+pub struct AllDebridProvider {
+    client: Client,
+}
+
+impl AllDebridProvider {
+    /// Create a new AllDebrid provider instance
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+
+    /// Create a new provider with a custom HTTP client
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Make an authenticated GET request
+    async fn get<T: for<'de> Deserialize<'de>>(
+        &self,
+        api_key: &str,
+        endpoint: &str,
+        extra_params: &[(&str, &str)],
+    ) -> Result<T, DebridError> {
+        let url = format!("{}{}", BASE_URL, endpoint);
+        debug!("AllDebrid GET: {}", url);
+
+        let mut request = self
+            .client
+            .get(&url)
+            .query(&[("agent", AGENT), ("apikey", api_key)]);
+
+        for (key, value) in extra_params {
+            request = request.query(&[(key, value)]);
+        }
+
+        let response = request.send().await?;
+        self.handle_response(response).await
+    }
+
+    /// Handle API response and parse errors
+    async fn handle_response<T: for<'de> Deserialize<'de>>(
+        &self,
+        response: reqwest::Response,
+    ) -> Result<T, DebridError> {
+        let _status = response.status();
+        let text = response.text().await?;
+        debug!("AllDebrid response: {}", text);
+
+        // AllDebrid always returns JSON with status field
+        let wrapper: AdApiResponse<T> = serde_json::from_str(&text).map_err(|e| {
+            error!("Failed to parse AllDebrid response: {} - {}", e, text);
+            DebridError::InternalError(format!("JSON parse error: {}", e))
+        })?;
+
+        if wrapper.status == "success" {
+            wrapper.data.ok_or_else(|| {
+                DebridError::InternalError("Missing data in success response".to_string())
+            })
+        } else {
+            let error = wrapper.error.unwrap_or_default();
+            Err(self.parse_error(&error.code, &error.message.unwrap_or_default()))
+        }
+    }
+
+    /// Parse error response from AllDebrid
+    fn parse_error(&self, code: &str, message: &str) -> DebridError {
+        match code {
+            "AUTH_MISSING_APIKEY" | "AUTH_BAD_APIKEY" | "AUTH_USER_BANNED" => {
+                DebridError::InvalidApiKey
+            }
+            "AUTH_BLOCKED" => DebridError::RateLimited(60),
+            "NO_SERVER" | "MAGNET_INVALID" | "MAGNET_MUST_BE_PREMIUM" => {
+                DebridError::MagnetNotSupported
+            }
+            "MAGNET_NO_URI" | "MAGNET_PROCESSING" => {
+                DebridError::ConversionFailed(message.to_string())
+            }
+            "MAGNET_TOO_MANY" => DebridError::QuotaExceeded,
+            "FREE_TRIAL_LIMIT_REACHED" | "MUST_BE_PREMIUM" => DebridError::SubscriptionExpired,
+            "LINK_HOST_NOT_SUPPORTED" | "LINK_DOWN" | "LINK_PASS_PROTECTED" => {
+                DebridError::MagnetNotSupported
+            }
+            "LINK_HOST_UNAVAILABLE" | "LINK_HOST_FULL" => {
+                DebridError::ConversionFailed(message.to_string())
+            }
+            _ => DebridError::ApiError {
+                code: 0,
+                message: format!("{}: {}", code, message),
+            },
+        }
+    }
+
+    /// Convert AllDebrid magnet status to our status enum
+    fn convert_status(status: &str, status_code: i32) -> TorrentStatusKind {
+        match status_code {
+            0 => TorrentStatusKind::Queued,       // Processing
+            1 => TorrentStatusKind::Downloading,  // Downloading
+            2 => TorrentStatusKind::Processing,   // Compressing
+            3 => TorrentStatusKind::Processing,   // Uploading
+            4 => TorrentStatusKind::Ready,        // Ready
+            5 => TorrentStatusKind::Error,        // Error
+            6 => TorrentStatusKind::Error,        // Virus
+            7 => TorrentStatusKind::Error,        // Dead
+            _ => match status.to_lowercase().as_str() {
+                "ready" => TorrentStatusKind::Ready,
+                "downloading" => TorrentStatusKind::Downloading,
+                "error" | "virus" | "dead" => TorrentStatusKind::Error,
+                _ => TorrentStatusKind::Processing,
+            },
+        }
+    }
+}
+
+impl Default for AllDebridProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl DebridProvider for AllDebridProvider {
+    fn id(&self) -> &'static str {
+        "all_debrid"
+    }
+
+    fn name(&self) -> &'static str {
+        "AllDebrid"
+    }
+
+    fn website_url(&self) -> &'static str {
+        "https://alldebrid.com"
+    }
+
+    async fn validate_api_key(&self, api_key: &str) -> Result<bool, DebridError> {
+        match self.get::<AdUserData>(api_key, "/user", &[]).await {
+            Ok(_) => Ok(true),
+            Err(DebridError::InvalidApiKey) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn get_subscription_info(&self, api_key: &str) -> Result<SubscriptionInfo, DebridError> {
+        let user: AdUserData = self.get(api_key, "/user", &[]).await?;
+
+        let expires_at = user.premium_until.and_then(|ts| {
+            Utc.timestamp_opt(ts, 0).single()
+        });
+
+        Ok(SubscriptionInfo {
+            is_premium: user.is_premium,
+            expires_at,
+            points: user.fidelity_points.map(|p| p as i64),
+            username: Some(user.username),
+        })
+    }
+
+    async fn add_magnet(&self, api_key: &str, magnet: &str) -> Result<String, DebridError> {
+        let response: AdMagnetUploadData = self
+            .get(api_key, "/magnet/upload", &[("magnets[]", magnet)])
+            .await?;
+
+        // Response contains array of magnets, we only sent one
+        let magnet_info = response
+            .magnets
+            .into_iter()
+            .next()
+            .ok_or_else(|| DebridError::InternalError("No magnet returned".to_string()))?;
+
+        if let Some(error) = magnet_info.error {
+            return Err(DebridError::ConversionFailed(format!(
+                "Magnet error: {} - {}",
+                error.code,
+                error.message.unwrap_or_default()
+            )));
+        }
+
+        let id = magnet_info
+            .id
+            .ok_or_else(|| DebridError::InternalError("No magnet ID returned".to_string()))?;
+
+        debug!("AllDebrid added magnet with ID: {}", id);
+        Ok(id.to_string())
+    }
+
+    async fn get_torrent_status(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<TorrentStatus, DebridError> {
+        let response: AdMagnetStatusData = self
+            .get(api_key, "/magnet/status", &[("id", remote_id)])
+            .await?;
+
+        let magnets = response.magnets;
+        let info = if let Some(magnet) = magnets.into_iter().next() {
+            magnet
+        } else {
+            return Err(DebridError::TorrentNotFound);
+        };
+
+        let status_kind = Self::convert_status(&info.status, info.status_code);
+
+        Ok(TorrentStatus {
+            id: info.id.to_string(),
+            status: status_kind,
+            progress: info.downloaded as f64 / info.size.max(1) as f64 * 100.0,
+            speed: info.download_speed.map(|s| s as u64),
+            size: Some(info.size as u64),
+            files_count: info.links.as_ref().map(|l| l.len()),
+            error_message: if info.status_code >= 5 {
+                Some(format!("Error status: {}", info.status))
+            } else {
+                None
+            },
+        })
+    }
+
+    async fn get_torrent_info(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<DebridTorrentInfo, DebridError> {
+        let response: AdMagnetStatusData = self
+            .get(api_key, "/magnet/status", &[("id", remote_id)])
+            .await?;
+
+        let info = response
+            .magnets
+            .into_iter()
+            .next()
+            .ok_or(DebridError::TorrentNotFound)?;
+
+        let status = TorrentStatus {
+            id: info.id.to_string(),
+            status: Self::convert_status(&info.status, info.status_code),
+            progress: info.downloaded as f64 / info.size.max(1) as f64 * 100.0,
+            speed: info.download_speed.map(|s| s as u64),
+            size: Some(info.size as u64),
+            files_count: info.links.as_ref().map(|l| l.len()),
+            error_message: None,
+        };
+
+        let files = info
+            .links
+            .unwrap_or_default()
+            .iter()
+            .enumerate()
+            .map(|(i, link)| DebridFile {
+                index: i,
+                name: link.filename.clone(),
+                size: link.size as u64,
+                selected: true, // AllDebrid doesn't have file selection
+                link: Some(link.link.clone()),
+            })
+            .collect();
+
+        let added_at = info.upload_date.and_then(|ts| Utc.timestamp_opt(ts, 0).single());
+
+        Ok(DebridTorrentInfo {
+            id: info.id.to_string(),
+            magnet: info.hash.unwrap_or_default(),
+            name: info.filename,
+            status,
+            files,
+            added_at,
+        })
+    }
+
+    async fn select_files(
+        &self,
+        _api_key: &str,
+        _remote_id: &str,
+        _file_indices: &[usize],
+    ) -> Result<(), DebridError> {
+        // AllDebrid doesn't support file selection - all files are downloaded
+        // This is a no-op
+        debug!("AllDebrid: select_files is a no-op (all files selected by default)");
+        Ok(())
+    }
+
+    async fn get_download_links(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<Vec<DirectLink>, DebridError> {
+        let response: AdMagnetStatusData = self
+            .get(api_key, "/magnet/status", &[("id", remote_id)])
+            .await?;
+
+        let info = response
+            .magnets
+            .into_iter()
+            .next()
+            .ok_or(DebridError::TorrentNotFound)?;
+
+        // Check if ready
+        if info.status_code != 4 {
+            return Err(DebridError::ConversionFailed(format!(
+                "Torrent not ready, status: {}",
+                info.status
+            )));
+        }
+
+        let links = info.links.ok_or_else(|| {
+            DebridError::ConversionFailed("No download links available".to_string())
+        })?;
+
+        // Unlock each link to get direct download URL
+        let mut direct_links = Vec::with_capacity(links.len());
+        for link in links {
+            match self.unlock_link(api_key, &link.link).await {
+                Ok(dl) => direct_links.push(dl),
+                Err(e) => {
+                    warn!("Failed to unlock link {}: {:?}", link.link, e);
+                    // Continue with other links
+                }
+            }
+        }
+
+        if direct_links.is_empty() {
+            return Err(DebridError::ConversionFailed(
+                "Failed to unlock any links".to_string(),
+            ));
+        }
+
+        Ok(direct_links)
+    }
+
+    async fn delete_torrent(&self, api_key: &str, remote_id: &str) -> Result<(), DebridError> {
+        let _: AdDeleteResponse = self
+            .get(api_key, "/magnet/delete", &[("id", remote_id)])
+            .await?;
+        Ok(())
+    }
+
+    async fn is_cached(&self, api_key: &str, magnet: &str) -> Result<bool, DebridError> {
+        // Extract hash from magnet
+        let hash = extract_hash_from_magnet(magnet);
+        if hash.is_none() {
+            return Ok(false);
+        }
+        let hash = hash.unwrap();
+
+        let response: AdInstantData = self
+            .get(api_key, "/magnet/instant", &[("magnets[]", &hash)])
+            .await?;
+
+        // Check if any magnet is instant available
+        Ok(response.magnets.iter().any(|m| m.instant))
+    }
+}
+
+impl AllDebridProvider {
+    /// Unlock a link to get direct download URL
+    async fn unlock_link(&self, api_key: &str, link: &str) -> Result<DirectLink, DebridError> {
+        let response: AdUnlockData = self
+            .get(api_key, "/link/unlock", &[("link", link)])
+            .await?;
+
+        Ok(DirectLink {
+            url: response.link,
+            filename: response.filename,
+            size: response.filesize as u64,
+        })
+    }
+}
+
+// ============================================================================
+// AllDebrid API Response Types
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+struct AdApiResponse<T> {
+    status: String,
+    data: Option<T>,
+    error: Option<AdError>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct AdError {
+    code: String,
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdUserData {
+    username: String,
+    #[serde(rename = "isPremium")]
+    is_premium: bool,
+    #[serde(rename = "premiumUntil")]
+    premium_until: Option<i64>,
+    #[serde(rename = "fidelityPoints")]
+    fidelity_points: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdMagnetUploadData {
+    magnets: Vec<AdMagnetUploadResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdMagnetUploadResult {
+    id: Option<i64>,
+    #[allow(dead_code)]
+    name: Option<String>,
+    #[allow(dead_code)]
+    hash: Option<String>,
+    #[allow(dead_code)]
+    ready: Option<bool>,
+    error: Option<AdError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdMagnetStatusData {
+    magnets: Vec<AdMagnetInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdMagnetInfo {
+    id: i64,
+    filename: String,
+    size: i64,
+    hash: Option<String>,
+    status: String,
+    #[serde(rename = "statusCode")]
+    status_code: i32,
+    downloaded: i64,
+    #[serde(rename = "downloadSpeed")]
+    download_speed: Option<i64>,
+    #[serde(rename = "uploadDate")]
+    upload_date: Option<i64>,
+    links: Option<Vec<AdMagnetLink>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdMagnetLink {
+    filename: String,
+    size: i64,
+    link: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdUnlockData {
+    link: String,
+    filename: String,
+    filesize: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdDeleteResponse {
+    #[allow(dead_code)]
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdInstantData {
+    magnets: Vec<AdInstantMagnet>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdInstantMagnet {
+    #[allow(dead_code)]
+    magnet: String,
+    #[allow(dead_code)]
+    hash: Option<String>,
+    instant: bool,
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Extract the info hash from a magnet link
+fn extract_hash_from_magnet(magnet: &str) -> Option<String> {
+    if let Some(start) = magnet.find("xt=urn:btih:") {
+        let hash_start = start + 12;
+        let remaining = &magnet[hash_start..];
+        let hash_end = remaining.find('&').unwrap_or(remaining.len());
+        let hash = &remaining[..hash_end];
+        if hash.len() >= 32 {
+            return Some(hash.to_lowercase());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_hash_from_magnet() {
+        let magnet = "magnet:?xt=urn:btih:ABC123DEF456ABC123DEF456ABC123DEF456ABC1&dn=test";
+        let hash = extract_hash_from_magnet(magnet);
+        assert!(hash.is_some());
+        assert_eq!(hash.unwrap(), "abc123def456abc123def456abc123def456abc1");
+    }
+
+    #[test]
+    fn test_convert_status() {
+        assert_eq!(
+            AllDebridProvider::convert_status("downloading", 1),
+            TorrentStatusKind::Downloading
+        );
+        assert_eq!(
+            AllDebridProvider::convert_status("ready", 4),
+            TorrentStatusKind::Ready
+        );
+        assert_eq!(
+            AllDebridProvider::convert_status("error", 5),
+            TorrentStatusKind::Error
+        );
+    }
+
+    #[test]
+    fn test_provider_info() {
+        let provider = AllDebridProvider::new();
+        assert_eq!(provider.id(), "all_debrid");
+        assert_eq!(provider.name(), "AllDebrid");
+        assert_eq!(provider.website_url(), "https://alldebrid.com");
+    }
+}
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/providers/mod.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/providers/mod.rs
@@ -1,0 +1,8 @@
+pub mod traits;
+pub mod real_debrid;
+pub mod all_debrid;
+
+pub use traits::*;
+pub use real_debrid::*;
+pub use all_debrid::*;
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/providers/real_debrid.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/providers/real_debrid.rs
@@ -1,0 +1,563 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use fit_launcher_ddl::DirectLink;
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{debug, error, warn};
+
+use crate::{
+    DebridError, DebridFile, DebridProvider, DebridTorrentInfo, SubscriptionInfo, TorrentStatus,
+    TorrentStatusKind,
+};
+
+const BASE_URL: &str = "https://api.real-debrid.com/rest/1.0";
+
+/// Real-Debrid API provider implementation
+pub struct RealDebridProvider {
+    client: Client,
+}
+
+impl RealDebridProvider {
+    /// Create a new Real-Debrid provider instance
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+
+    /// Create a new provider with a custom HTTP client
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Make an authenticated GET request
+    async fn get<T: for<'de> Deserialize<'de>>(
+        &self,
+        api_key: &str,
+        endpoint: &str,
+    ) -> Result<T, DebridError> {
+        let url = format!("{}{}", BASE_URL, endpoint);
+        debug!("Real-Debrid GET: {}", url);
+
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(api_key)
+            .send()
+            .await?;
+
+        self.handle_response(response).await
+    }
+
+    /// Make an authenticated POST request with form data
+    async fn post<T: for<'de> Deserialize<'de>>(
+        &self,
+        api_key: &str,
+        endpoint: &str,
+        form: &[(&str, &str)],
+    ) -> Result<T, DebridError> {
+        let url = format!("{}{}", BASE_URL, endpoint);
+        debug!("Real-Debrid POST: {} with {:?}", url, form);
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(api_key)
+            .form(form)
+            .send()
+            .await?;
+
+        self.handle_response(response).await
+    }
+
+    /// Make an authenticated DELETE request
+    async fn delete(&self, api_key: &str, endpoint: &str) -> Result<(), DebridError> {
+        let url = format!("{}{}", BASE_URL, endpoint);
+        debug!("Real-Debrid DELETE: {}", url);
+
+        let response = self
+            .client
+            .delete(&url)
+            .bearer_auth(api_key)
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            error!("Real-Debrid DELETE error: {} - {}", status, text);
+            Err(self.parse_error(status.as_u16(), &text))
+        }
+    }
+
+    /// Handle API response and parse errors
+    async fn handle_response<T: for<'de> Deserialize<'de>>(
+        &self,
+        response: reqwest::Response,
+    ) -> Result<T, DebridError> {
+        let status = response.status();
+
+        if status.is_success() {
+            let text = response.text().await?;
+            debug!("Real-Debrid response: {}", text);
+            serde_json::from_str(&text).map_err(|e| {
+                error!("Failed to parse Real-Debrid response: {} - {}", e, text);
+                DebridError::InternalError(format!("JSON parse error: {}", e))
+            })
+        } else {
+            let text = response.text().await.unwrap_or_default();
+            error!("Real-Debrid API error: {} - {}", status, text);
+            Err(self.parse_error(status.as_u16(), &text))
+        }
+    }
+
+    /// Parse error response from Real-Debrid
+    fn parse_error(&self, status: u16, body: &str) -> DebridError {
+        // Try to parse as JSON error
+        if let Ok(err) = serde_json::from_str::<RdErrorResponse>(body) {
+            return match err.error_code {
+                1 => DebridError::InternalError("Missing parameter".to_string()),
+                2 => DebridError::InvalidApiKey,
+                3 => DebridError::InvalidApiKey, // Unknown token
+                4 => DebridError::InvalidApiKey, // Token expired
+                5 => DebridError::SubscriptionExpired,
+                8 => DebridError::MagnetNotSupported,
+                9 => DebridError::InternalError("Permission denied".to_string()),
+                10 => DebridError::TorrentNotFound,
+                11 => DebridError::QuotaExceeded,
+                12 => DebridError::RateLimited(60),
+                20 => DebridError::MagnetNotSupported, // Unsupported hoster
+                21 => DebridError::MagnetNotSupported, // Hoster in maintenance
+                22 => DebridError::MagnetNotSupported, // Hoster limit reached
+                23 => DebridError::QuotaExceeded, // Hoster not available for free
+                24 => DebridError::QuotaExceeded, // Too many downloads
+                25 => DebridError::MagnetNotSupported, // IP not allowed
+                _ => DebridError::ApiError {
+                    code: err.error_code,
+                    message: err.error,
+                },
+            };
+        }
+
+        // Fallback based on HTTP status
+        match status {
+            401 => DebridError::InvalidApiKey,
+            403 => DebridError::SubscriptionExpired,
+            404 => DebridError::TorrentNotFound,
+            429 => DebridError::RateLimited(60),
+            _ => DebridError::ApiError {
+                code: status as i32,
+                message: body.to_string(),
+            },
+        }
+    }
+
+    /// Convert Real-Debrid torrent status to our status enum
+    fn convert_status(status: &str) -> TorrentStatusKind {
+        match status {
+            "magnet_error" | "error" | "virus" | "dead" => TorrentStatusKind::Error,
+            "magnet_conversion" | "waiting_files_selection" => TorrentStatusKind::Queued,
+            "queued" | "downloading" => TorrentStatusKind::Downloading,
+            "uploading" | "compressing" => TorrentStatusKind::Processing,
+            "downloaded" => TorrentStatusKind::Ready,
+            _ => TorrentStatusKind::Queued,
+        }
+    }
+}
+
+impl Default for RealDebridProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl DebridProvider for RealDebridProvider {
+    fn id(&self) -> &'static str {
+        "real_debrid"
+    }
+
+    fn name(&self) -> &'static str {
+        "Real-Debrid"
+    }
+
+    fn website_url(&self) -> &'static str {
+        "https://real-debrid.com"
+    }
+
+    async fn validate_api_key(&self, api_key: &str) -> Result<bool, DebridError> {
+        match self.get::<RdUserResponse>(api_key, "/user").await {
+            Ok(_) => Ok(true),
+            Err(DebridError::InvalidApiKey) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn get_subscription_info(&self, api_key: &str) -> Result<SubscriptionInfo, DebridError> {
+        let user: RdUserResponse = self.get(api_key, "/user").await?;
+
+        let expires_at = user.expiration.and_then(|exp| {
+            DateTime::parse_from_rfc3339(&exp)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        });
+
+        Ok(SubscriptionInfo {
+            is_premium: user.premium > 0,
+            expires_at,
+            points: Some(user.points),
+            username: Some(user.username),
+        })
+    }
+
+    async fn add_magnet(&self, api_key: &str, magnet: &str) -> Result<String, DebridError> {
+        let response: RdAddMagnetResponse = self
+            .post(api_key, "/torrents/addMagnet", &[("magnet", magnet)])
+            .await?;
+
+        debug!("Real-Debrid added magnet with ID: {}", response.id);
+        Ok(response.id)
+    }
+
+    async fn get_torrent_status(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<TorrentStatus, DebridError> {
+        let info: RdTorrentInfoResponse = self
+            .get(api_key, &format!("/torrents/info/{}", remote_id))
+            .await?;
+
+        let status_kind = Self::convert_status(&info.status);
+        let progress = info.progress as f64;
+
+        Ok(TorrentStatus {
+            id: info.id,
+            status: status_kind,
+            progress,
+            speed: info.speed.map(|s| s as u64),
+            size: Some(info.bytes as u64),
+            files_count: Some(info.files.len()),
+            error_message: if info.status == "error" || info.status == "magnet_error" {
+                Some("Torrent error".to_string())
+            } else {
+                None
+            },
+        })
+    }
+
+    async fn get_torrent_info(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<DebridTorrentInfo, DebridError> {
+        let info: RdTorrentInfoResponse = self
+            .get(api_key, &format!("/torrents/info/{}", remote_id))
+            .await?;
+
+        let status = TorrentStatus {
+            id: info.id.clone(),
+            status: Self::convert_status(&info.status),
+            progress: info.progress as f64,
+            speed: info.speed.map(|s| s as u64),
+            size: Some(info.bytes as u64),
+            files_count: Some(info.files.len()),
+            error_message: None,
+        };
+
+        let files = info
+            .files
+            .iter()
+            .map(|f| DebridFile {
+                index: f.id as usize,
+                name: f.path.clone(),
+                size: f.bytes as u64,
+                selected: f.selected == 1,
+                link: None,
+            })
+            .collect();
+
+        let added_at = info.added.and_then(|a| {
+            DateTime::parse_from_rfc3339(&a)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        });
+
+        Ok(DebridTorrentInfo {
+            id: info.id,
+            magnet: info.original_filename.unwrap_or_default(),
+            name: info.filename,
+            status,
+            files,
+            added_at,
+        })
+    }
+
+    async fn select_files(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+        file_indices: &[usize],
+    ) -> Result<(), DebridError> {
+        let files_param = if file_indices.is_empty() {
+            "all".to_string()
+        } else {
+            file_indices
+                .iter()
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+
+        // This endpoint returns empty on success
+        let _: serde_json::Value = self
+            .post(
+                api_key,
+                &format!("/torrents/selectFiles/{}", remote_id),
+                &[("files", &files_param)],
+            )
+            .await
+            .or_else(|e| {
+                // Some versions return empty response which fails JSON parsing
+                if matches!(e, DebridError::InternalError(_)) {
+                    Ok(serde_json::Value::Null)
+                } else {
+                    Err(e)
+                }
+            })?;
+
+        debug!("Real-Debrid selected files: {}", files_param);
+        Ok(())
+    }
+
+    async fn get_download_links(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<Vec<DirectLink>, DebridError> {
+        let info: RdTorrentInfoResponse = self
+            .get(api_key, &format!("/torrents/info/{}", remote_id))
+            .await?;
+
+        // Check if torrent is ready
+        if info.status != "downloaded" {
+            return Err(DebridError::ConversionFailed(format!(
+                "Torrent not ready, status: {}",
+                info.status
+            )));
+        }
+
+        // Get the links from the torrent info
+        let links = info.links;
+        if links.is_empty() {
+            return Err(DebridError::ConversionFailed(
+                "No download links available".to_string(),
+            ));
+        }
+
+        // Unrestrict each link to get direct download URLs
+        let mut direct_links = Vec::with_capacity(links.len());
+        for link in links {
+            match self.unrestrict_link(api_key, &link).await {
+                Ok(dl) => direct_links.push(dl),
+                Err(e) => {
+                    warn!("Failed to unrestrict link {}: {:?}", link, e);
+                    // Continue with other links
+                }
+            }
+        }
+
+        if direct_links.is_empty() {
+            return Err(DebridError::ConversionFailed(
+                "Failed to unrestrict any links".to_string(),
+            ));
+        }
+
+        Ok(direct_links)
+    }
+
+    async fn delete_torrent(&self, api_key: &str, remote_id: &str) -> Result<(), DebridError> {
+        self.delete(api_key, &format!("/torrents/delete/{}", remote_id))
+            .await
+    }
+
+    async fn is_cached(&self, api_key: &str, magnet: &str) -> Result<bool, DebridError> {
+        // Extract hash from magnet link
+        let hash = extract_hash_from_magnet(magnet);
+        if hash.is_none() {
+            return Ok(false);
+        }
+        let hash = hash.unwrap();
+
+        // Check instant availability
+        let url = format!("/torrents/instantAvailability/{}", hash);
+        let response: serde_json::Value = self.get(api_key, &url).await?;
+
+        // If the hash exists and has data, it's cached
+        if let Some(obj) = response.as_object() {
+            if let Some(hash_data) = obj.get(&hash.to_lowercase()) {
+                if let Some(arr) = hash_data.as_array() {
+                    return Ok(!arr.is_empty());
+                }
+                if let Some(obj) = hash_data.as_object() {
+                    return Ok(!obj.is_empty());
+                }
+            }
+        }
+
+        Ok(false)
+    }
+}
+
+impl RealDebridProvider {
+    /// Unrestrict a single link
+    async fn unrestrict_link(&self, api_key: &str, link: &str) -> Result<DirectLink, DebridError> {
+        let response: RdUnrestrictResponse = self
+            .post(api_key, "/unrestrict/link", &[("link", link)])
+            .await?;
+
+        Ok(DirectLink {
+            url: response.download,
+            filename: response.filename,
+            size: response.filesize as u64,
+        })
+    }
+}
+
+// ============================================================================
+// Real-Debrid API Response Types
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+struct RdErrorResponse {
+    error: String,
+    error_code: i32,
+}
+
+#[derive(Debug, Deserialize)]
+struct RdUserResponse {
+    username: String,
+    premium: i32,
+    points: i64,
+    expiration: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RdAddMagnetResponse {
+    id: String,
+    #[allow(dead_code)]
+    uri: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RdTorrentInfoResponse {
+    id: String,
+    filename: String,
+    original_filename: Option<String>,
+    #[allow(dead_code)]
+    hash: String,
+    bytes: i64,
+    progress: f32,
+    status: String,
+    speed: Option<i64>,
+    files: Vec<RdTorrentFile>,
+    links: Vec<String>,
+    added: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RdTorrentFile {
+    id: i32,
+    path: String,
+    bytes: i64,
+    selected: i32,
+}
+
+#[derive(Debug, Deserialize)]
+struct RdUnrestrictResponse {
+    #[allow(dead_code)]
+    id: String,
+    filename: String,
+    filesize: i64,
+    download: String,
+    #[allow(dead_code)]
+    #[serde(rename = "type")]
+    mime_type: Option<String>,
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Extract the info hash from a magnet link
+fn extract_hash_from_magnet(magnet: &str) -> Option<String> {
+    // Look for xt=urn:btih: parameter
+    if let Some(start) = magnet.find("xt=urn:btih:") {
+        let hash_start = start + 12;
+        let remaining = &magnet[hash_start..];
+
+        // Hash ends at next & or end of string
+        let hash_end = remaining.find('&').unwrap_or(remaining.len());
+        let hash = &remaining[..hash_end];
+
+        // Hash should be 40 hex chars or 32 base32 chars
+        if hash.len() >= 32 {
+            return Some(hash.to_lowercase());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_hash_from_magnet() {
+        let magnet = "magnet:?xt=urn:btih:ABC123DEF456ABC123DEF456ABC123DEF456ABC1&dn=test";
+        let hash = extract_hash_from_magnet(magnet);
+        assert!(hash.is_some());
+        assert_eq!(
+            hash.unwrap(),
+            "abc123def456abc123def456abc123def456abc1"
+        );
+    }
+
+    #[test]
+    fn test_extract_hash_no_hash() {
+        let magnet = "magnet:?dn=test";
+        let hash = extract_hash_from_magnet(magnet);
+        assert!(hash.is_none());
+    }
+
+    #[test]
+    fn test_convert_status() {
+        assert_eq!(
+            RealDebridProvider::convert_status("downloading"),
+            TorrentStatusKind::Downloading
+        );
+        assert_eq!(
+            RealDebridProvider::convert_status("downloaded"),
+            TorrentStatusKind::Ready
+        );
+        assert_eq!(
+            RealDebridProvider::convert_status("error"),
+            TorrentStatusKind::Error
+        );
+        assert_eq!(
+            RealDebridProvider::convert_status("queued"),
+            TorrentStatusKind::Downloading
+        );
+    }
+
+    #[test]
+    fn test_provider_info() {
+        let provider = RealDebridProvider::new();
+        assert_eq!(provider.id(), "real_debrid");
+        assert_eq!(provider.name(), "Real-Debrid");
+        assert_eq!(provider.website_url(), "https://real-debrid.com");
+    }
+}
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/providers/traits.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/providers/traits.rs
@@ -1,0 +1,92 @@
+use async_trait::async_trait;
+use fit_launcher_ddl::DirectLink;
+
+use crate::{
+    error::DebridError, DebridTorrentInfo, ProviderInfo, SubscriptionInfo, TorrentStatus,
+};
+
+/// Trait that all debrid providers must implement
+///
+/// This trait defines the common interface for interacting with debrid services.
+/// Each provider (Real-Debrid, AllDebrid, etc.) implements this trait.
+#[async_trait]
+pub trait DebridProvider: Send + Sync {
+    /// Get the unique identifier for this provider
+    fn id(&self) -> &'static str;
+
+    /// Get the display name for this provider
+    fn name(&self) -> &'static str;
+
+    /// Get provider information
+    fn info(&self) -> ProviderInfo {
+        ProviderInfo {
+            id: self.id().to_string(),
+            name: self.name().to_string(),
+            website_url: self.website_url().to_string(),
+        }
+    }
+
+    /// Get the website URL for this provider
+    fn website_url(&self) -> &'static str;
+
+    /// Validate an API key
+    ///
+    /// Returns `Ok(true)` if the key is valid, `Ok(false)` if invalid,
+    /// or an error if the validation request failed.
+    async fn validate_api_key(&self, api_key: &str) -> Result<bool, DebridError>;
+
+    /// Get subscription information for the authenticated user
+    async fn get_subscription_info(&self, api_key: &str) -> Result<SubscriptionInfo, DebridError>;
+
+    /// Add a magnet link to the debrid service
+    ///
+    /// Returns the remote ID of the torrent on the debrid service.
+    async fn add_magnet(&self, api_key: &str, magnet: &str) -> Result<String, DebridError>;
+
+    /// Get the current status of a torrent
+    async fn get_torrent_status(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<TorrentStatus, DebridError>;
+
+    /// Get detailed information about a torrent including files
+    async fn get_torrent_info(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<DebridTorrentInfo, DebridError>;
+
+    /// Select which files to download from the torrent
+    ///
+    /// Pass an empty slice to select all files.
+    async fn select_files(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+        file_indices: &[usize],
+    ) -> Result<(), DebridError>;
+
+    /// Get direct download links for a ready torrent
+    ///
+    /// This may involve "unrestricting" links depending on the provider.
+    async fn get_download_links(
+        &self,
+        api_key: &str,
+        remote_id: &str,
+    ) -> Result<Vec<DirectLink>, DebridError>;
+
+    /// Delete a torrent from the debrid service
+    async fn delete_torrent(&self, api_key: &str, remote_id: &str) -> Result<(), DebridError>;
+
+    /// Check if a magnet link is supported/cached by this provider
+    ///
+    /// Returns `Ok(true)` if the torrent is already cached on the provider.
+    async fn is_cached(&self, api_key: &str, magnet: &str) -> Result<bool, DebridError> {
+        // Default implementation: assume not cached
+        // Providers can override with actual cache check
+        let _ = (api_key, magnet);
+        Ok(false)
+    }
+}
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/registry.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/registry.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::{DebridError, DebridProvider, ProviderInfo};
+
+/// Registry for managing available debrid providers
+///
+/// The registry holds references to all available debrid provider implementations
+/// and allows for dynamic lookup and instantiation.
+pub struct DebridRegistry {
+    providers: HashMap<String, Arc<dyn DebridProvider>>,
+}
+
+impl DebridRegistry {
+    /// Create a new empty registry
+    pub fn new() -> Self {
+        Self {
+            providers: HashMap::new(),
+        }
+    }
+
+    /// Register a new provider
+    ///
+    /// The provider's ID is used as the key for lookup.
+    pub fn register<P: DebridProvider + 'static>(&mut self, provider: P) {
+        let id = provider.id().to_string();
+        self.providers.insert(id, Arc::new(provider));
+    }
+
+    /// Register a provider from an Arc
+    pub fn register_arc(&mut self, provider: Arc<dyn DebridProvider>) {
+        let id = provider.id().to_string();
+        self.providers.insert(id, provider);
+    }
+
+    /// Get a provider by ID
+    pub fn get(&self, id: &str) -> Option<Arc<dyn DebridProvider>> {
+        self.providers.get(id).cloned()
+    }
+
+    /// Check if a provider is registered
+    pub fn has(&self, id: &str) -> bool {
+        self.providers.contains_key(id)
+    }
+
+    /// Get a provider by ID, returning an error if not found
+    pub fn get_or_err(&self, id: &str) -> Result<Arc<dyn DebridProvider>, DebridError> {
+        self.get(id)
+            .ok_or_else(|| DebridError::ProviderNotFound(id.to_string()))
+    }
+
+    /// List all registered providers
+    pub fn list_providers(&self) -> Vec<ProviderInfo> {
+        self.providers.values().map(|p| p.info()).collect()
+    }
+
+    /// Get the IDs of all registered providers
+    pub fn provider_ids(&self) -> Vec<String> {
+        self.providers.keys().cloned().collect()
+    }
+
+    /// Get the number of registered providers
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    /// Check if the registry is empty
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+
+    /// Remove a provider by ID
+    pub fn unregister(&mut self, id: &str) -> Option<Arc<dyn DebridProvider>> {
+        self.providers.remove(id)
+    }
+
+    /// Clear all providers
+    pub fn clear(&mut self) {
+        self.providers.clear();
+    }
+}
+
+impl Default for DebridRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test that the registry compiles and basic operations work
+    // Actual provider tests will be added when providers are implemented
+
+    #[test]
+    fn test_registry_new() {
+        let registry = DebridRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+    }
+
+    #[test]
+    fn test_registry_list_empty() {
+        let registry = DebridRegistry::new();
+        let providers = registry.list_providers();
+        assert!(providers.is_empty());
+    }
+}
+

--- a/src-tauri/local-crates/fit-launcher-debrid/src/types.rs
+++ b/src-tauri/local-crates/fit-launcher-debrid/src/types.rs
@@ -1,0 +1,159 @@
+use chrono::{DateTime, Utc};
+use fit_launcher_ddl::DirectLink;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+/// Information about a debrid provider
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ProviderInfo {
+    /// Unique identifier for the provider (e.g., "real_debrid", "all_debrid")
+    pub id: String,
+    /// Display name (e.g., "Real-Debrid", "AllDebrid")
+    pub name: String,
+    /// Website URL for the provider
+    pub website_url: String,
+}
+
+/// Subscription information from a debrid provider
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct SubscriptionInfo {
+    /// Whether the user has an active premium subscription
+    pub is_premium: bool,
+    /// When the subscription expires (if premium)
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Available points/credits (provider-specific)
+    pub points: Option<i64>,
+    /// Username on the service
+    pub username: Option<String>,
+}
+
+/// Status of a torrent being processed by a debrid service
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub enum TorrentStatusKind {
+    /// Torrent is queued for processing
+    Queued,
+    /// Torrent is being downloaded by the debrid service
+    Downloading,
+    /// Torrent is being processed/converted
+    Processing,
+    /// Torrent is ready for download
+    Ready,
+    /// Torrent processing failed
+    Error,
+    /// Torrent was deleted
+    Deleted,
+}
+
+/// Detailed status of a torrent on a debrid service
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct TorrentStatus {
+    /// Remote ID on the debrid service
+    pub id: String,
+    /// Current status
+    pub status: TorrentStatusKind,
+    /// Progress percentage (0-100)
+    pub progress: f64,
+    /// Download speed (bytes/s) on the debrid service
+    pub speed: Option<u64>,
+    /// Total size in bytes
+    pub size: Option<u64>,
+    /// Number of files in the torrent
+    pub files_count: Option<usize>,
+    /// Error message if status is Error
+    pub error_message: Option<String>,
+}
+
+/// Information about a file in a debrid torrent
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct DebridFile {
+    /// File index in the torrent
+    pub index: usize,
+    /// File name
+    pub name: String,
+    /// File size in bytes
+    pub size: u64,
+    /// Whether the file is selected for download
+    pub selected: bool,
+    /// Direct download link (available when ready)
+    pub link: Option<String>,
+}
+
+/// Complete information about a torrent on a debrid service
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct DebridTorrentInfo {
+    /// Remote ID on the debrid service
+    pub id: String,
+    /// Original magnet link
+    pub magnet: String,
+    /// Torrent name/title
+    pub name: String,
+    /// Current status
+    pub status: TorrentStatus,
+    /// Files in the torrent
+    pub files: Vec<DebridFile>,
+    /// When the torrent was added
+    pub added_at: Option<DateTime<Utc>>,
+}
+
+/// Result of unrestricting a link (getting the final download URL)
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct UnrestrictedLink {
+    /// Original link that was unrestricted
+    pub original: String,
+    /// Final direct download URL
+    pub download_url: String,
+    /// File name
+    pub filename: String,
+    /// File size in bytes
+    pub size: u64,
+    /// MIME type if available
+    pub mime_type: Option<String>,
+}
+
+impl From<UnrestrictedLink> for DirectLink {
+    fn from(link: UnrestrictedLink) -> Self {
+        DirectLink {
+            url: link.download_url,
+            filename: link.filename,
+            size: link.size,
+        }
+    }
+}
+
+/// Configuration for a debrid provider
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Default)]
+pub struct DebridProviderConfig {
+    /// Provider ID
+    pub provider_id: String,
+    /// Whether this provider is enabled
+    pub enabled: bool,
+    /// API key (should be stored securely)
+    pub api_key: Option<String>,
+}
+
+/// Global debrid settings
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Default)]
+pub struct DebridSettings {
+    /// Configured providers
+    pub providers: Vec<DebridProviderConfig>,
+    /// Default provider to use
+    pub default_provider: Option<String>,
+    /// Whether to automatically fall back to torrent if debrid fails
+    pub auto_fallback: bool,
+}
+
+/// Event emitted during debrid conversion
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct DebridConversionEvent {
+    /// Job ID in the download manager
+    pub job_id: String,
+    /// Provider being used
+    pub provider: String,
+    /// Current status
+    pub status: TorrentStatusKind,
+    /// Progress percentage
+    pub progress: f64,
+    /// Error message if failed
+    pub error: Option<String>,
+}
+

--- a/src-tauri/local-crates/fit-launcher-download-manager/Cargo.toml
+++ b/src-tauri/local-crates/fit-launcher-download-manager/Cargo.toml
@@ -15,6 +15,7 @@ tracing = { workspace = true }
 fit-launcher-aria2 = { workspace = true }
 fit-launcher-torrent = { workspace = true }
 fit-launcher-ddl = { path = "../fit-launcher-ddl" }
+fit-launcher-debrid = { path = "../fit-launcher-debrid" }
 sha2 = "0.10.9"
 tauri = { workspace = true }
 directories = { workspace = true }

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/error.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/error.rs
@@ -27,4 +27,13 @@ pub enum DownloadManagerError {
 
     #[error("I/O error: {0}")]
     IoError(String),
+
+    #[error("Debrid conversion failed: {0}")]
+    DebridConversionFailed(String),
+
+    #[error("Debrid conversion timed out")]
+    DebridConversionTimeout,
+
+    #[error("Debrid provider not found: {0}")]
+    DebridProviderNotFound(String),
 }

--- a/src/api/debrid/api.ts
+++ b/src/api/debrid/api.ts
@@ -1,0 +1,277 @@
+import { commands } from "../../bindings";
+
+/**
+ * Provider information from the backend
+ */
+export type ProviderInfo = {
+  id: string;
+  name: string;
+  website_url: string;
+};
+
+/**
+ * Subscription information from a debrid provider
+ */
+export type SubscriptionInfo = {
+  is_premium: boolean;
+  expires_at: string | null;
+  points: number | null;
+  username: string | null;
+};
+
+/**
+ * Stored credentials for a provider
+ */
+export type StoredCredentials = {
+  provider_id: string;
+  api_key_encoded: string;
+  enabled: boolean;
+};
+
+/**
+ * Debrid settings
+ */
+export type DebridSettings = {
+  default_provider: string | null;
+  auto_fallback: boolean;
+};
+
+/**
+ * Debrid API wrapper for frontend use
+ */
+export const DebridApi = {
+  /**
+   * List all available debrid providers
+   */
+  async listProviders(): Promise<ProviderInfo[]> {
+    try {
+      const result = await commands.debridListProviders();
+      return result as ProviderInfo[];
+    } catch (error) {
+      console.error("Failed to list providers:", error);
+      return [];
+    }
+  },
+
+  /**
+   * Validate an API key for a provider
+   */
+  async validateApiKey(providerId: string, apiKey: string): Promise<boolean> {
+    try {
+      const result = await commands.debridValidateApiKey(providerId, apiKey);
+      if (result.status === "ok") {
+        return result.data;
+      }
+      console.error("API key validation error:", result.error);
+      return false;
+    } catch (error) {
+      console.error("Failed to validate API key:", error);
+      return false;
+    }
+  },
+
+  /**
+   * Get subscription information for a provider
+   */
+  async getSubscription(
+    providerId: string,
+    apiKey: string
+  ): Promise<SubscriptionInfo | null> {
+    try {
+      const result = await commands.debridGetSubscription(providerId, apiKey);
+      if (result.status === "ok") {
+        return result.data as SubscriptionInfo;
+      }
+      console.error("Subscription error:", result.error);
+      return null;
+    } catch (error) {
+      console.error("Failed to get subscription:", error);
+      return null;
+    }
+  },
+
+  /**
+   * Check if a magnet is cached (instant available) on a provider
+   */
+  async isCached(
+    providerId: string,
+    apiKey: string,
+    magnet: string
+  ): Promise<boolean> {
+    try {
+      const result = await commands.debridIsCached(providerId, apiKey, magnet);
+      if (result.status === "ok") {
+        return result.data;
+      }
+      return false;
+    } catch (error) {
+      console.error("Failed to check cache:", error);
+      return false;
+    }
+  },
+
+  /**
+   * Save credentials for a provider
+   */
+  async saveCredentials(
+    providerId: string,
+    apiKey: string,
+    enabled: boolean
+  ): Promise<boolean> {
+    try {
+      const result = await commands.debridSaveCredentials(
+        providerId,
+        apiKey,
+        enabled
+      );
+      return result.status === "ok";
+    } catch (error) {
+      console.error("Failed to save credentials:", error);
+      return false;
+    }
+  },
+
+  /**
+   * Get credentials for a provider (note: api_key is encoded)
+   */
+  async getCredentials(providerId: string): Promise<StoredCredentials | null> {
+    try {
+      const result = await commands.debridGetCredentials(providerId);
+      if (result.status === "ok") {
+        return result.data as StoredCredentials | null;
+      }
+      return null;
+    } catch (error) {
+      console.error("Failed to get credentials:", error);
+      return null;
+    }
+  },
+
+  /**
+   * Get the decoded API key for a provider
+   */
+  async getApiKey(providerId: string): Promise<string | null> {
+    try {
+      const result = await commands.debridGetApiKey(providerId);
+      if (result.status === "ok") {
+        return result.data;
+      }
+      return null;
+    } catch (error) {
+      console.error("Failed to get API key:", error);
+      return null;
+    }
+  },
+
+  /**
+   * List all configured providers (those with saved credentials)
+   */
+  async listConfiguredProviders(): Promise<StoredCredentials[]> {
+    try {
+      const result = await commands.debridListConfiguredProviders();
+      if (result.status === "ok") {
+        return result.data as StoredCredentials[];
+      }
+      return [];
+    } catch (error) {
+      console.error("Failed to list configured providers:", error);
+      return [];
+    }
+  },
+
+  /**
+   * Remove credentials for a provider
+   */
+  async removeCredentials(providerId: string): Promise<boolean> {
+    try {
+      const result = await commands.debridRemoveCredentials(providerId);
+      return result.status === "ok";
+    } catch (error) {
+      console.error("Failed to remove credentials:", error);
+      return false;
+    }
+  },
+
+  /**
+   * Get debrid settings
+   */
+  async getSettings(): Promise<DebridSettings> {
+    try {
+      const result = await commands.debridGetSettings();
+      if (result.status === "ok") {
+        return result.data as DebridSettings;
+      }
+      return { default_provider: null, auto_fallback: false };
+    } catch (error) {
+      console.error("Failed to get settings:", error);
+      return { default_provider: null, auto_fallback: false };
+    }
+  },
+
+  /**
+   * Save debrid settings
+   */
+  async saveSettings(settings: DebridSettings): Promise<boolean> {
+    try {
+      const result = await commands.debridSaveSettings(settings);
+      return result.status === "ok";
+    } catch (error) {
+      console.error("Failed to save settings:", error);
+      return false;
+    }
+  },
+
+  /**
+   * Set the default provider
+   */
+  async setDefaultProvider(providerId: string | null): Promise<boolean> {
+    try {
+      const result = await commands.debridSetDefaultProvider(providerId);
+      return result.status === "ok";
+    } catch (error) {
+      console.error("Failed to set default provider:", error);
+      return false;
+    }
+  },
+
+  /**
+   * Check if any provider is configured and enabled
+   */
+  async hasConfiguredProvider(): Promise<boolean> {
+    try {
+      const result = await commands.debridHasConfiguredProvider();
+      if (result.status === "ok") {
+        return result.data;
+      }
+      return false;
+    } catch (error) {
+      console.error("Failed to check configured provider:", error);
+      return false;
+    }
+  },
+
+  /**
+   * Get the list of enabled providers with their info
+   */
+  async getEnabledProviders(): Promise<
+    Array<ProviderInfo & { credentials: StoredCredentials }>
+  > {
+    const providers = await this.listProviders();
+    const configured = await this.listConfiguredProviders();
+
+    const enabled: Array<ProviderInfo & { credentials: StoredCredentials }> =
+      [];
+
+    for (const cred of configured) {
+      if (cred.enabled) {
+        const providerInfo = providers.find((p) => p.id === cred.provider_id);
+        if (providerInfo) {
+          enabled.push({ ...providerInfo, credentials: cred });
+        }
+      }
+    }
+
+    return enabled;
+  },
+};
+

--- a/src/pages/Settings-01/Settings-Categories/Download/Debrid/DebridPart.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Download/Debrid/DebridPart.tsx
@@ -1,0 +1,305 @@
+import { createSignal, createEffect, For, Show, onMount, type JSX } from "solid-js";
+import PageGroup from "../../Components/PageGroup";
+import { DebridApi, ProviderInfo, StoredCredentials, SubscriptionInfo } from "../../../../../api/debrid/api";
+import Button from "../../../../../components/UI/Button/Button";
+import { CheckCircle, XCircle, Loader2, ExternalLink, Clock } from "lucide-solid";
+
+type ProviderState = {
+  provider: ProviderInfo;
+  credentials: StoredCredentials | null;
+  apiKey: string;
+  enabled: boolean;
+  subscription: SubscriptionInfo | null;
+  validating: boolean;
+  validated: boolean;
+  error: string | null;
+};
+
+export default function DebridPart(): JSX.Element {
+  const [providers, setProviders] = createSignal<ProviderState[]>([]);
+  const [loading, setLoading] = createSignal(true);
+
+  onMount(async () => {
+    await loadProviders();
+  });
+
+  async function loadProviders() {
+    setLoading(true);
+    try {
+      const providerList = await DebridApi.listProviders();
+      const configured = await DebridApi.listConfiguredProviders();
+
+      const states: ProviderState[] = [];
+      for (const provider of providerList) {
+        const cred = configured.find((c) => c.provider_id === provider.id);
+        let apiKey = "";
+        
+        // Get the decoded API key if credentials exist
+        if (cred) {
+          const key = await DebridApi.getApiKey(provider.id);
+          apiKey = key || "";
+        }
+
+        states.push({
+          provider,
+          credentials: cred || null,
+          apiKey,
+          enabled: cred?.enabled || false,
+          subscription: null,
+          validating: false,
+          validated: false,
+          error: null,
+        });
+      }
+      setProviders(states);
+    } catch (error) {
+      console.error("Failed to load providers:", error);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function updateProvider(id: string, updates: Partial<ProviderState>) {
+    setProviders((prev) =>
+      prev.map((p) =>
+        p.provider.id === id ? { ...p, ...updates } : p
+      )
+    );
+  }
+
+  async function handleTestConnection(providerId: string) {
+    const state = providers().find((p) => p.provider.id === providerId);
+    if (!state || !state.apiKey) return;
+
+    updateProvider(providerId, { validating: true, error: null, subscription: null, validated: false });
+
+    try {
+      const isValid = await DebridApi.validateApiKey(providerId, state.apiKey);
+      if (isValid) {
+        const sub = await DebridApi.getSubscription(providerId, state.apiKey);
+        updateProvider(providerId, { 
+          subscription: sub, 
+          validated: true, 
+          validating: false,
+          error: null
+        });
+      } else {
+        updateProvider(providerId, { 
+          validated: false, 
+          validating: false, 
+          error: "Invalid API key" 
+        });
+      }
+    } catch (error) {
+      updateProvider(providerId, { 
+        validated: false, 
+        validating: false, 
+        error: "Connection failed" 
+      });
+    }
+  }
+
+  async function handleSave(providerId: string) {
+    const state = providers().find((p) => p.provider.id === providerId);
+    if (!state) return;
+
+    const success = await DebridApi.saveCredentials(
+      providerId,
+      state.apiKey,
+      state.enabled
+    );
+
+    if (success) {
+      updateProvider(providerId, { 
+        credentials: { 
+          provider_id: providerId, 
+          api_key_encoded: "", 
+          enabled: state.enabled 
+        } 
+      });
+    }
+  }
+
+  async function handleRemove(providerId: string) {
+    const success = await DebridApi.removeCredentials(providerId);
+    if (success) {
+      updateProvider(providerId, { 
+        credentials: null, 
+        apiKey: "", 
+        enabled: false, 
+        subscription: null, 
+        validated: false 
+      });
+    }
+  }
+
+  return (
+    <PageGroup title="Debrid Services">
+      <p class="text-muted text-sm mb-4">
+        Configure debrid services for faster downloads. Debrid services convert torrent links 
+        to direct download links, providing faster speeds without requiring a VPN.
+      </p>
+
+      <Show when={!loading()} fallback={
+        <div class="flex items-center justify-center py-8">
+          <Loader2 class="w-6 h-6 animate-spin text-accent" />
+          <span class="ml-2 text-muted">Loading providers...</span>
+        </div>
+      }>
+        <div class="flex flex-col gap-4">
+          <For each={providers()}>
+            {(state) => (
+              <ProviderCard
+                state={state}
+                onApiKeyChange={(key) => updateProvider(state.provider.id, { apiKey: key })}
+                onEnabledChange={(enabled) => updateProvider(state.provider.id, { enabled })}
+                onTest={() => handleTestConnection(state.provider.id)}
+                onSave={() => handleSave(state.provider.id)}
+                onRemove={() => handleRemove(state.provider.id)}
+              />
+            )}
+          </For>
+        </div>
+      </Show>
+    </PageGroup>
+  );
+}
+
+type ProviderCardProps = {
+  state: ProviderState;
+  onApiKeyChange: (key: string) => void;
+  onEnabledChange: (enabled: boolean) => void;
+  onTest: () => void;
+  onSave: () => void;
+  onRemove: () => void;
+};
+
+function ProviderCard(props: ProviderCardProps): JSX.Element {
+  const { state } = props;
+
+  return (
+    <div class="bg-background-30 rounded-lg border border-secondary-20 p-4">
+      {/* Header */}
+      <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-3">
+          <div class="w-10 h-10 rounded-lg bg-secondary-20 flex items-center justify-center">
+            <span class="text-lg font-bold text-accent">
+              {state.provider.name.charAt(0)}
+            </span>
+          </div>
+          <div>
+            <h3 class="font-semibold text-text">{state.provider.name}</h3>
+            <a 
+              href={state.provider.website_url} 
+              target="_blank" 
+              rel="noopener noreferrer"
+              class="text-xs text-muted hover:text-accent flex items-center gap-1"
+            >
+              {state.provider.website_url.replace(/^https?:\/\//, '')}
+              <ExternalLink class="w-3 h-3" />
+            </a>
+          </div>
+        </div>
+
+        {/* Status indicator */}
+        <div class="flex items-center gap-2">
+          <Show when={state.validated}>
+            <span class="flex items-center gap-1 text-green-500 text-sm">
+              <CheckCircle class="w-4 h-4" />
+              Connected
+            </span>
+          </Show>
+          <Show when={state.error}>
+            <span class="flex items-center gap-1 text-red-500 text-sm">
+              <XCircle class="w-4 h-4" />
+              {state.error}
+            </span>
+          </Show>
+        </div>
+      </div>
+
+      {/* API Key Input */}
+      <div class="mb-4">
+        <label class="block text-sm text-muted mb-1">API Key</label>
+        <input
+          type="password"
+          value={state.apiKey}
+          onInput={(e) => props.onApiKeyChange(e.currentTarget.value)}
+          placeholder="Enter your API key"
+          class="w-full bg-background border border-secondary-20 rounded-lg px-3 py-2 text-text placeholder-muted focus:border-accent focus:outline-none transition-colors"
+        />
+      </div>
+
+      {/* Enable Toggle */}
+      <div class="flex items-center justify-between mb-4">
+        <span class="text-sm text-text">Enable this provider</span>
+        <label class="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            checked={state.enabled}
+            onChange={(e) => props.onEnabledChange(e.currentTarget.checked)}
+            class="sr-only peer"
+          />
+          <div class="w-11 h-6 bg-secondary-20 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-accent"></div>
+        </label>
+      </div>
+
+      {/* Subscription Info */}
+      <Show when={state.subscription}>
+        <div class="bg-background/50 rounded-lg p-3 mb-4 border border-secondary-20">
+          <div class="grid grid-cols-2 gap-2 text-sm">
+            <div>
+              <span class="text-muted">Username:</span>
+              <span class="text-text ml-2">{state.subscription?.username || "N/A"}</span>
+            </div>
+            <div>
+              <span class="text-muted">Status:</span>
+              <span class={`ml-2 ${state.subscription?.is_premium ? "text-green-500" : "text-yellow-500"}`}>
+                {state.subscription?.is_premium ? "Premium" : "Free"}
+              </span>
+            </div>
+            <Show when={state.subscription?.expires_at}>
+              <div class="col-span-2 flex items-center gap-1">
+                <Clock class="w-4 h-4 text-muted" />
+                <span class="text-muted">Expires:</span>
+                <span class="text-text ml-1">
+                  {new Date(state.subscription!.expires_at!).toLocaleDateString()}
+                </span>
+              </div>
+            </Show>
+            <Show when={state.subscription?.points !== null && state.subscription?.points !== undefined}>
+              <div>
+                <span class="text-muted">Points:</span>
+                <span class="text-text ml-2">{state.subscription?.points}</span>
+              </div>
+            </Show>
+          </div>
+        </div>
+      </Show>
+
+      {/* Actions */}
+      <div class="flex items-center gap-2">
+        <Button
+          onClick={props.onTest}
+          label={state.validating ? "Testing..." : "Test Connection"}
+          variant="outline"
+          disabled={!state.apiKey || state.validating}
+        />
+        <Button
+          onClick={props.onSave}
+          label="Save"
+          variant="solid"
+          disabled={!state.apiKey}
+        />
+        <Show when={state.credentials}>
+          <Button
+            onClick={props.onRemove}
+            label="Remove"
+            variant="outline"
+          />
+        </Show>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/Settings-01/Settings-Categories/Download/Download.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Download/Download.tsx
@@ -16,6 +16,7 @@ import TransferLimitsPart from "./TransferLimits/TransferLimits";
 import NetworkPart from "./Network/NetworkPart";
 import BittorrentPart from "./Bittorrent/BittorrentPart";
 import AriaPart from "./AriaPart/AriaPart";
+import DebridPart from "./Debrid/DebridPart";
 
 
 
@@ -121,6 +122,9 @@ function DownloadConfigurationPage(props: { settingsPart: DownloadSettingsPart }
               handleSwitchCheckChange={handleSwitchCheckChange}
               handleTextCheckChange={handleTextCheckChange}
             />
+          ),
+          debrid: (
+            <DebridPart />
           )
         }[selectedPart()] ?? <p>Invalid or Unsupported Part</p>}
 

--- a/src/pages/Settings-01/Settings.tsx
+++ b/src/pages/Settings-01/Settings.tsx
@@ -17,7 +17,8 @@ import {
   Monitor,
   HardDriveDownload,
   Archive,
-  Info
+  Info,
+  Zap
 } from "lucide-solid";
 
 import type {
@@ -114,6 +115,7 @@ function SettingsSidebar(): JSX.Element {
             <SidebarLink id="settings-limits" label="Transfer Limits" icon={Gauge} onClick={() => handleActivateElem("settings-limits", "limits")} />
             <SidebarLink id="settings-network" label="Network" icon={Globe} onClick={() => handleActivateElem("settings-network", "network")} />
             <SidebarLink id="settings-bittorrent" label="Bittorrent" icon={Magnet} onClick={() => handleActivateElem("settings-bittorrent", "bittorrent")} />
+            <SidebarLink id="settings-debrid" label="Debrid Services" icon={Zap} onClick={() => handleActivateElem("settings-debrid", "debrid")} />
             <SidebarLink id="settings-rpc" label="Aria2 RPC" icon={Cpu} onClick={() => handleActivateElem("settings-rpc", "rpc")} />
           </ul>
         </div>

--- a/src/types/settings/types.ts
+++ b/src/types/settings/types.ts
@@ -49,7 +49,8 @@ export type DownloadSettingsPart =
   | "limits"
   | "network"
   | "bittorrent"
-  | "rpc";
+  | "rpc"
+  | "debrid";
 
 export type SettingsPart = GlobalSettingsPart | DownloadSettingsPart;
 


### PR DESCRIPTION
## Summary

This PR implements debrid services support as requested in #7. Debrid services convert magnet links to direct download links, providing faster download speeds without requiring a VPN.

## Important Disclaimer

**I was unable to test this implementation with actual debrid accounts.** The API integrations are based on official documentation:
- [Real-Debrid API](https://api.real-debrid.com/)
- [AllDebrid API](https://docs.alldebrid.com/)

This implementation requires testing by community members who have active subscriptions before merging.

## What's Implemented

### Backend (Rust)
- New `fit-launcher-debrid` crate following the existing pattern
- `DebridProvider` trait for modular provider support
- Real-Debrid and AllDebrid provider implementations
- Extended `DownloadManager` with `add_debrid_job()` method
- Secure credential storage in app config
- Tauri commands for frontend integration

### Frontend (SolidJS/TypeScript)
- Settings page with Debrid Services section
- Download popup with BitTorrent/Debrid method selector
- DebridApi wrapper for all operations
- Event handling for conversion progress

## How It Works

1. User configures API key in Settings → Debrid Services
2. When downloading a torrent, user can choose "Debrid" method
3. Magnet link is sent to debrid service
4. Service converts it to direct download links
5. aria2 downloads the files directly

## Testing Needed

- [ ] Real-Debrid: API key validation
- [ ] Real-Debrid: Magnet to direct link conversion
- [ ] Real-Debrid: Full download flow
- [ ] AllDebrid: Same tests as above
- [ ] Error handling scenarios

## Questions for Maintainers

1. Is the credential storage approach acceptable?
2. Should we add more providers in follow-up PRs?
3. Any architectural concerns?

---

Happy to make any changes based on feedback. Thank you for considering this contribution!

Closes #7