### PR TITLE
feat(installer): event-driven installer monitoring with WinEvent hooks

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -193,6 +193,7 @@ once_cell = "1.21.3"
 rand = { version = "0.9.2", features = ["small_rng"] }
 futures = "0.3.31"
 futures-util = "0.3"
+tokio-util = "0.7"
 
 # Parsing and scraping
 scraper = "0.24.0"

--- a/src-tauri/local-crates/fit-launcher-bin-installer/src/lib.rs
+++ b/src-tauri/local-crates/fit-launcher-bin-installer/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod events;
+
+pub use events::win_events;

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/commands.rs
@@ -89,7 +89,13 @@ pub async fn dm_run_automate_setup_install(
     );
     let id = state.create_job(job.game, job.job_path).await;
 
-    state.start_job(id, app_handle.clone()).await;
+    // Spawn the installation as a background task
+    // events.rs will emit setup::hook::started and setup::hook::stopped directly
+    let state_clone = state.inner().clone();
+    let app_handle_clone = app_handle.clone();
+    tokio::spawn(async move {
+        state_clone.start_job(id, app_handle_clone).await;
+    });
 
     Ok(id)
 }

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/manager.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/manager.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tauri::{Emitter, State};
 use tokio::sync::RwLock;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 /// Debounce time for saving to disk
 const SAVE_DEBOUNCE_MS: u64 = 400;
@@ -634,7 +634,8 @@ impl DownloadManager {
 
             self.request_save_debounced().await;
         } else {
-            error!("Received update for unknown gid: {}", gid);
+            // This can happen for stale GIDs from completed/removed downloads
+            debug!("Received update for unknown gid: {}", gid);
         }
 
         Ok(())

--- a/src-tauri/local-crates/fit-launcher-torrent/src/hooks.rs
+++ b/src-tauri/local-crates/fit-launcher-torrent/src/hooks.rs
@@ -14,8 +14,8 @@ pub(crate) mod windows {
         SetInformationJobObject,
     };
     use windows::Win32::System::Threading::{
-        CREATE_SUSPENDED, CreateProcessW, PROCESS_INFORMATION, ResumeThread, STARTUPINFOW,
-        TerminateProcess,
+        CREATE_NO_WINDOW, CREATE_SUSPENDED, CreateProcessW, PROCESS_CREATION_FLAGS,
+        PROCESS_INFORMATION, ResumeThread, STARTUPINFOW, TerminateProcess,
     };
 
     use windows::core::{PCWSTR, PWSTR};
@@ -151,7 +151,7 @@ pub(crate) mod windows {
                 None,
                 None,
                 false,
-                CREATE_SUSPENDED,
+                CREATE_SUSPENDED | CREATE_NO_WINDOW,
                 None,
                 lp_dir,
                 &si,

--- a/src-tauri/local-crates/fit-launcher-ui-automation/Cargo.toml
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/Cargo.toml
@@ -29,6 +29,8 @@ windows = { workspace = true, features = [
     "Win32_Media_Audio_Endpoints",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
+    "Win32_UI_Accessibility",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 windows-result = { workspace = true }
 

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/emitter/setup.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/emitter/setup.rs
@@ -1,14 +1,17 @@
+use std::sync::mpsc::RecvTimeoutError;
 use std::time::Duration;
 
 use serde::Serialize;
 use tauri::Emitter;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::mighty::{
-    automation::win32::{find_completed_setup, poll_progress_bar_percentage},
-    retry_until_async,
+#[cfg(target_os = "windows")]
+use crate::winevents::win_events::{
+    InstallEvent, InstallPhase, mark_hook_failed, monitor_install_events_with_handle, stop_monitor,
 };
+
+use crate::mighty::automation::win32::{find_completed_setup, kill_process_by_pid};
 
 #[derive(Serialize, Clone)]
 pub struct JobProgress {
@@ -16,84 +19,244 @@ pub struct JobProgress {
     pub percentage: f32,
 }
 
-/// Emits progress updates via Tauri events
+#[derive(Serialize, Clone, Debug)]
+pub struct PhaseUpdate {
+    pub id: Uuid,
+    pub phase: String,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct FileUpdate {
+    pub id: Uuid,
+    pub path: String,
+}
+
+/// Uses SetWinEventHook instead of polling - events fire as window titles change.
+/// If installer_pid is provided, only monitors that specific process.
+#[cfg(target_os = "windows")]
 pub async fn progress_bar_setup_emit(
     app_handle: tauri::AppHandle,
     cancel: tokio_util::sync::CancellationToken,
     id: Uuid,
-) {
+    install_path: Option<String>,
+    installer_pid: Option<u32>,
+    root_pid: Option<u32>,
+) -> bool {
     let mut latest: f32 = 0.0;
-    let mut interval_ms = 50;
-    let mut consecutive_none = 0;
-    const MAX_NONE: u32 = 5;
-    const MAX_INTERVAL_MS: u64 = 500;
+    let mut current_phase: Option<InstallPhase> = None;
+    let mut no_event_count = 0;
+    const MAX_NO_EVENTS: u32 = 120;
+
+    let target_pid = installer_pid.unwrap_or(0);
+    let rx = match monitor_install_events_with_handle(
+        app_handle.clone(),
+        id,
+        target_pid,
+        install_path,
+    ) {
+        Ok(rx) => rx,
+        Err(e) => {
+            warn!(
+                "Failed to start event monitor: {}. Falling back to completion check.",
+                e
+            );
+            return false;
+        }
+    };
+
+    info!(
+        "Started event-driven progress monitoring for job {} (PID: {})",
+        id, target_pid
+    );
+
+    let mut setup_pid: Option<u32> = installer_pid;
 
     loop {
-        tokio::select! {
-            _ = cancel.cancelled() => {
-                let _ = app_handle.emit(
-                    "setup::progress::cancelled",
-                    JobProgress { id, percentage: latest }
-                );
-                break;
-            }
+        if cancel.is_cancelled() {
+            info!("Installation cancelled by user");
+            mark_hook_failed();
+            stop_monitor();
+            return false;
+        }
 
-            _ = tokio::time::sleep(Duration::from_millis(interval_ms)) => {
-                let mut attempts = 0;
+        match rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(event) => {
+                no_event_count = 0;
 
+                match event {
+                    InstallEvent::Phase { phase } => {
+                        if current_phase.as_ref() != Some(&phase) {
+                            let phase_name = format!("{:?}", phase);
+                            info!("Phase changed to: {:?}", phase);
+                            current_phase = Some(phase.clone());
 
-                let mut value = None;
+                            let _ = app_handle.emit(
+                                "setup::phase::updated",
+                                PhaseUpdate {
+                                    id,
+                                    phase: phase_name,
+                                },
+                            );
 
-                while attempts < MAX_NONE {
-                    if let Some(p) = poll_progress_bar_percentage() {
-                        value = Some(p);
-                        break;
-                    }
+                            // Finalizing phase - poll for success text to determine outcome
+                            if matches!(phase, InstallPhase::Finalizing) {
+                                info!("Detected Finalizing phase, checking for success...");
+                                // Give it a moment for the window content to update
+                                std::thread::sleep(Duration::from_millis(500));
 
-                    attempts += 1;
-                    tokio::time::sleep(Duration::from_millis(interval_ms)).await;
-                }
-
-                match value {
-                    Some(p) => {
-                        latest = p;
-                        consecutive_none = 0;
-                    }
-                    None => {
-                        consecutive_none += 1;
-                        if consecutive_none >= MAX_NONE {
-                            // completed setup fallback
-                            let completed = find_completed_setup();
-                            if completed {
-                                let _ = app_handle.emit(
-                                    "setup::progress::finished",
-                                    JobProgress { id, percentage: 100.0 },
-                                );
-                            } else {
-                                let _ = app_handle.emit(
-                                    "setup::progress::cancelled",
-                                    JobProgress { id, percentage: latest },
-                                );
+                                if find_completed_setup() {
+                                    info!(
+                                        "Installation completed successfully (found success text)"
+                                    );
+                                    // Kill child process first, then root process
+                                    if let Some(child_pid) = installer_pid {
+                                        kill_process_by_pid(child_pid);
+                                    }
+                                    if let Some(parent_pid) = root_pid {
+                                        kill_process_by_pid(parent_pid);
+                                    }
+                                    stop_monitor();
+                                    return true;
+                                } else {
+                                    warn!(
+                                        "Installation failed (no success text found in finalizing screen)"
+                                    );
+                                    mark_hook_failed();
+                                    if let Some(child_pid) = installer_pid {
+                                        kill_process_by_pid(child_pid);
+                                    }
+                                    if let Some(parent_pid) = root_pid {
+                                        kill_process_by_pid(parent_pid);
+                                    }
+                                    stop_monitor();
+                                    return false;
+                                }
                             }
-                            break;
+
+                            if matches!(phase, InstallPhase::Completed) {
+                                info!(
+                                    "Installation completed successfully, terminating installer processes"
+                                );
+                                // Kill child process first, then root process
+                                if let Some(child_pid) = installer_pid {
+                                    kill_process_by_pid(child_pid);
+                                }
+                                if let Some(parent_pid) = root_pid {
+                                    kill_process_by_pid(parent_pid);
+                                }
+                                stop_monitor();
+                                return true;
+                            }
+
+                            if matches!(phase, InstallPhase::Failed) {
+                                warn!("Installation failed");
+                                mark_hook_failed();
+                                stop_monitor();
+                                return false;
+                            }
                         }
                     }
+
+                    InstallEvent::Progress { percent } => {
+                        latest = percent;
+                        debug!("Progress: {:.1}%", percent);
+
+                        let _ = app_handle.emit(
+                            "setup::progress::updated",
+                            JobProgress {
+                                id,
+                                percentage: percent,
+                            },
+                        );
+                    }
+
+                    InstallEvent::File { path } => {
+                        debug!("Extracting: {}", path);
+                        let _ = app_handle.emit("setup::file::updated", FileUpdate { id, path });
+                    }
+
+                    InstallEvent::GameTitle { title } => {
+                        debug!("Game title detected: {}", title);
+
+                        if current_phase.as_ref() != Some(&InstallPhase::Welcome) {
+                            current_phase = Some(InstallPhase::Welcome);
+                            let _ = app_handle.emit(
+                                "setup::phase::updated",
+                                PhaseUpdate {
+                                    id,
+                                    phase: "Welcome".to_string(),
+                                },
+                            );
+                        }
+                    }
+
+                    InstallEvent::Closed => {
+                        info!("Setup window closed");
+                        if latest >= 100.0 || matches!(current_phase, Some(InstallPhase::Completed))
+                        {
+                            stop_monitor();
+                            return true;
+                        } else {
+                            mark_hook_failed();
+                            stop_monitor();
+                            return false;
+                        }
+                    }
+
+                    InstallEvent::InstallPath { .. }
+                    | InstallEvent::Components { .. }
+                    | InstallEvent::DiskSpace { .. } => {}
                 }
+            }
 
-                // emit always
-                let _ = app_handle.emit(
-                    "setup::progress::updated",
-                    JobProgress { id, percentage: latest },
-                );
+            Err(RecvTimeoutError::Timeout) => {
+                no_event_count += 1;
 
-                if latest >= 100.0 {
-                    let _ = app_handle.emit(
-                        "setup::progress::finished",
-                        JobProgress { id, percentage: latest },
+                if no_event_count >= MAX_NO_EVENTS {
+                    info!(
+                        "No events for {} seconds, checking if setup completed...",
+                        MAX_NO_EVENTS / 2
                     );
-                    break;
+
+                    if find_completed_setup() {
+                        info!("Found completed setup window");
+                        stop_monitor();
+                        return true;
+                    } else {
+                        warn!("Setup appears to have stalled or closed unexpectedly");
+                        if let Some(pid) = setup_pid {
+                            kill_process_by_pid(pid);
+                        }
+
+                        mark_hook_failed();
+                        stop_monitor();
+                        return false;
+                    }
+                }
+            }
+
+            Err(RecvTimeoutError::Disconnected) => {
+                info!("Event monitor channel disconnected");
+                if latest >= 100.0 || find_completed_setup() {
+                    return true;
+                } else {
+                    mark_hook_failed();
+                    return false;
                 }
             }
         }
     }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub async fn progress_bar_setup_emit(
+    _app_handle: tauri::AppHandle,
+    _cancel: tokio_util::sync::CancellationToken,
+    _id: Uuid,
+    _install_path: Option<String>,
+    _installer_pid: Option<u32>,
+    _root_pid: Option<u32>,
+) -> bool {
+    warn!("Event-driven progress monitoring is only supported on Windows");
+    false
 }

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/lib.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/lib.rs
@@ -3,10 +3,13 @@ pub mod extraction;
 pub mod mighty;
 pub mod mighty_automation;
 pub mod mighty_commands;
+pub mod process_utils;
+pub mod winevents;
 use std::time::Duration;
 
 pub use extraction::*;
 pub use mighty_commands::*;
+pub use process_utils::*;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use thiserror::Error;

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/mighty_automation.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/mighty_automation.rs
@@ -1,261 +1,135 @@
+use crate::InstallationError;
+use crate::mighty::automation::*;
+use fit_launcher_config::commands::get_installation_settings;
+use std::path::PathBuf;
+use std::process::Command;
+use std::{thread, time};
+use tracing::info;
+
 #[cfg(target_os = "windows")]
-/// DEPRECATED VERSION
+use crate::process_utils::is_running_as_admin;
+
+//TODO: Add one for specifical VERY_SILENT mode but only for no 2gb limit and nothing specifical.
+
+/// Start an executable and return its PID for process tree tracking.
+pub fn start_executable_components_args(path: PathBuf) -> Result<u32, InstallationError> {
+    #[cfg(target_os = "windows")]
+    {
+        if !is_running_as_admin() {
+            return Err(InstallationError::AdminModeError);
+        }
+
+        let installation_settings = get_installation_settings();
+        let mut checkboxes_list: Vec<String> = Vec::new();
+
+        if installation_settings.directx_install {
+            checkboxes_list.push("directx".to_string());
+        }
+        if installation_settings.microsoftcpp_install {
+            checkboxes_list.push("microsoft".to_string());
+        }
+        let components = checkboxes_list.join(",");
+        let args_list = format!("/COMPONENTS=\"{components}\"");
+
+        let temp_path = path.with_extension("temp_setup.exe");
+
+        std::fs::copy(&path, &temp_path).map_err(|e| InstallationError::IOError(e.to_string()))?;
+
+        let child = Command::new(&temp_path)
+            .arg(args_list)
+            .spawn()
+            .map_err(|e| InstallationError::IOError(e.to_string()))?;
+
+        let pid = child.id();
+        info!("Executable started with PID: {}", pid);
+
+        Ok(pid)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Err(InstallationError::IOError(
+            "Not supported on this platform".to_string(),
+        ))
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub async fn automate_until_download(path_to_game: &str) {
+    // Skip Select Setup Language.
+
+    click_ok_button();
+    // Skip Select Setup Language.
+    thread::sleep(time::Duration::from_millis(1000));
+    mute_setup();
+    let should_two_gb_limit = get_installation_settings().two_gb_limit;
+    if should_two_gb_limit {
+        // mute song by default
+        thread::sleep(time::Duration::from_millis(1000));
+        // Skip until checkboxes.
+        thread::sleep(time::Duration::from_millis(1000));
+        click_8gb_limit();
+        thread::sleep(time::Duration::from_millis(200));
+        click_next_button();
+        click_next_button();
+        // Skip until checkboxes.
+        // Change path input, important for both cases.
+        change_path_input(path_to_game);
+        click_next_button();
+        // Change path input, important for both cases.
+        // Start Installation.
+        click_install_button();
+        // Start Installation.
+    } else if !should_two_gb_limit && !check_8gb_limit() {
+        thread::sleep(time::Duration::from_millis(1000));
+        click_next_button();
+        click_next_button();
+        // Change path input, important for both cases.
+        info!("Path input will be: {}", path_to_game);
+        change_path_input(path_to_game);
+        click_next_button();
+        // Change path input, important for both cases.
+        // Start Installation.
+        click_install_button();
+        // Start Installation.
+    } else if !should_two_gb_limit && check_8gb_limit() {
+        // Skip until checkboxes.
+        thread::sleep(time::Duration::from_millis(1000));
+        click_8gb_limit();
+        thread::sleep(time::Duration::from_millis(200));
+        click_next_button();
+        click_next_button();
+        // Skip until checkboxes.
+        // Change path input, important for both cases.
+        change_path_input(path_to_game);
+        click_next_button();
+        // Change path input, important for both cases.
+        // Start Installation.
+        click_install_button();
+        // Start Installation.
+    }
+
+    thread::sleep(time::Duration::from_millis(1000));
+
+    // * No need for this anymore since we can contact the components directly through commandline.
+    // My stupid self forgor that this was still usable :(
+    // // Uncheck (Because they are all checked before hand) the checkboxes given by the user to uncheck.
+    // thread::sleep(time::Duration::from_millis(1000));
+    // checklist_automation::get_checkboxes_from_list(user_checkboxes_to_check);
+    // thread::sleep(time::Duration::from_millis(1000));
+    // // Uncheck (Because they are all checked before hand) the checkboxes given by the user to uncheck.
+}
+
+/// This function will start an executable using Wine.
 ///
-/// PLEASE USE start_executable_components_args(path: String, checkboxes_list: &[String]) INSTEAD
-#[allow(dead_code)]
-mod checklist_automation {
-    use tracing::{error, info, warn};
-
-    #[cfg(target_os = "windows")]
-    use uiautomation::types::UIProperty::{ClassName, NativeWindowHandle, ToggleToggleState};
-
-    #[cfg(target_os = "windows")]
-    use uiautomation::{UIAutomation, UIElement};
-
-    fn get_checklistbox() -> Result<UIElement, uiautomation::errors::Error> {
-        let automation = UIAutomation::new().unwrap();
-
-        let checklistbox_element = automation.create_matcher().classname("TNewCheckListBox");
-
-        // println!("{:#?}", sec_elem.unwrap());
-
-        checklistbox_element.find_first()
-    }
-
-    #[cfg(target_os = "windows")]
-    pub fn get_checkboxes_from_list(list_to_check: Vec<String>) {
-        use tracing::warn;
-
-        let automation = UIAutomation::new().unwrap();
-        let walker = automation.get_control_view_walker().unwrap();
-
-        let checklistbox_elem = match get_checklistbox() {
-            Ok(elem) => elem,
-            Err(e) => {
-                warn!("Failed to find checklist box: {}", e);
-                return;
-            }
-        };
-
-        if let Ok(child) = walker.get_first_child(&checklistbox_elem) {
-            let ch = &child;
-            {
-                process_element(ch.clone(), list_to_check.clone());
-            }
-
-            let mut next = child;
-            while let Ok(sibling) = walker.get_next_sibling(&next) {
-                let sib = &sibling;
-                {
-                    process_element(sib.clone(), list_to_check.clone());
-                }
-                next = sibling;
-            }
-        }
-    }
-
-    fn process_element(element: UIElement, chkbx_to_check: Vec<String>) {
-        let el = &element;
-        {
-            // Get various properties and patterns as before
-            let spec_classname = el.get_property_value(ClassName).unwrap(); // NULL
-            let spec_proc_handle = el.get_property_value(NativeWindowHandle).unwrap();
-
-            let spec_toggle_toggle_state = el.get_property_value(ToggleToggleState).unwrap(); // NULL
-            let spec_control_type = el.get_control_type().unwrap();
-
-            let spec_text_inside = el.get_name().unwrap();
-            info!(
-                "ClassName = {:#?} and HWND = {:#?} and ControlType = {:#?} and TTState = {:#?} and CheckboxText = {:#?}",
-                spec_classname.to_string(),
-                spec_proc_handle.to_string(),
-                spec_control_type.to_string(),
-                spec_toggle_toggle_state.to_string(),
-                spec_text_inside
-            );
-
-            chkbx_to_check.iter().for_each(|chkbx| {
-                if spec_text_inside.contains(chkbx) {
-                    match el.send_keys(" ", 0) {
-                        Ok(_) => info!("Space key sent to element."),
-                        Err(e) => error!("Failed to send space key: {:?}", e),
-                    }
-                    match el.send_keys(" ", 0) {
-                        Ok(_) => info!("Space key sent to element."),
-                        Err(e) => error!("Failed to send space key: {:?}", e),
-                    }
-                } else {
-                    warn!("skipped : {:#?}", spec_text_inside);
-                }
-            });
-        }
-    }
-}
-
-#[cfg(target_os = "windows")]
-pub mod windows_ui_automation {
-    use crate::InstallationError;
-    use crate::mighty::automation::*;
-    use fit_launcher_config::commands::get_installation_settings;
-    use std::path::PathBuf;
-    use std::process::Command;
-    use std::{thread, time};
-    use tracing::info;
-
-    #[cfg(target_os = "windows")]
-    fn is_running_as_admin() -> bool {
-        use windows::Win32::{
-            Foundation::{CloseHandle, HANDLE},
-            Security::{GetTokenInformation, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation},
-            System::Threading::{GetCurrentProcess, OpenProcessToken},
-        };
-
-        unsafe {
-            let processhandle = GetCurrentProcess();
-            let mut tokenhandle = HANDLE(std::ptr::null_mut());
-            let desiredaccess = TOKEN_QUERY;
-            if OpenProcessToken(processhandle, desiredaccess, &mut tokenhandle as _).is_err() {
-                return false;
-            }
-
-            let mut tokeninformation = TOKEN_ELEVATION::default();
-            let mut needed = 0_u32;
-
-            let result = GetTokenInformation(
-                tokenhandle,
-                TokenElevation,
-                Some(&mut tokeninformation as *mut _ as _),
-                size_of::<TOKEN_ELEVATION>() as u32,
-                &mut needed as _,
-            )
-            .map(|_| tokeninformation.TokenIsElevated != 0);
-
-            _ = CloseHandle(tokenhandle);
-
-            result
-        }
-        .unwrap_or_default()
-    }
-
-    //TODO: Add one for specifical VERY_SILENT mode but only for no 2gb limit and nothing specifical.
-
-    /// Start an executable using tauri::command and gets the components that needs to be checked.
-    ///
-    pub fn start_executable_components_args(path: PathBuf) -> Result<(), InstallationError> {
-        #[cfg(target_os = "windows")]
-        {
-            if !is_running_as_admin() {
-                return Err(InstallationError::AdminModeError);
-            }
-
-            let installation_settings = get_installation_settings();
-            let mut checkboxes_list: Vec<String> = Vec::new();
-
-            if installation_settings.directx_install {
-                checkboxes_list.push("directx".to_string());
-            }
-            if installation_settings.microsoftcpp_install {
-                checkboxes_list.push("microsoft".to_string());
-            }
-            let components = checkboxes_list.join(",");
-            let args_list = format!("/COMPONENTS=\"{components}\"");
-
-            let temp_path = path.with_extension("temp_setup.exe");
-
-            std::fs::copy(&path, &temp_path)
-                .map_err(|e| InstallationError::IOError(e.to_string()))?;
-
-            Command::new(&temp_path)
-                .arg(args_list)
-                .spawn()
-                .map_err(|e| InstallationError::IOError(e.to_string()))?;
-
-            info!("Executable started successfully.");
-        }
-
-        Ok(())
-    }
-
-    #[cfg(target_os = "windows")]
-    pub async fn automate_until_download(path_to_game: &str) {
-        // Skip Select Setup Language.
-
-        use crate::emitter::setup::progress_bar_setup_emit;
-        click_ok_button();
-        // Skip Select Setup Language.
-        thread::sleep(time::Duration::from_millis(1000));
-        mute_setup();
-        let should_two_gb_limit = get_installation_settings().two_gb_limit;
-        if should_two_gb_limit {
-            // mute song by default
-            thread::sleep(time::Duration::from_millis(1000));
-            // Skip until checkboxes.
-            thread::sleep(time::Duration::from_millis(1000));
-            click_8gb_limit();
-            thread::sleep(time::Duration::from_millis(200));
-            click_next_button();
-            click_next_button();
-            // Skip until checkboxes.
-            // Change path input, important for both cases.
-            change_path_input(path_to_game);
-            click_next_button();
-            // Change path input, important for both cases.
-            // Start Installation.
-            click_install_button();
-            // Start Installation.
-        } else if !should_two_gb_limit && !check_8gb_limit() {
-            thread::sleep(time::Duration::from_millis(1000));
-            click_next_button();
-            click_next_button();
-            // Change path input, important for both cases.
-            info!("Path input will be: {}", path_to_game);
-            change_path_input(path_to_game);
-            click_next_button();
-            // Change path input, important for both cases.
-            // Start Installation.
-            click_install_button();
-            // Start Installation.
-        } else if !should_two_gb_limit && check_8gb_limit() {
-            // Skip until checkboxes.
-            thread::sleep(time::Duration::from_millis(1000));
-            click_8gb_limit();
-            thread::sleep(time::Duration::from_millis(200));
-            click_next_button();
-            click_next_button();
-            // Skip until checkboxes.
-            // Change path input, important for both cases.
-            change_path_input(path_to_game);
-            click_next_button();
-            // Change path input, important for both cases.
-            // Start Installation.
-            click_install_button();
-            // Start Installation.
-        }
-
-        thread::sleep(time::Duration::from_millis(1000));
-
-        // * No need for this anymore since we can contact the components directly through commandline.
-        // My stupid self forgor that this was still usable :(
-        // // Uncheck (Because they are all checked before hand) the checkboxes given by the user to uncheck.
-        // thread::sleep(time::Duration::from_millis(1000));
-        // checklist_automation::get_checkboxes_from_list(user_checkboxes_to_check);
-        // thread::sleep(time::Duration::from_millis(1000));
-        // // Uncheck (Because they are all checked before hand) the checkboxes given by the user to uncheck.
-    }
-}
-
-pub mod linux_ui_automation {
-
-    /// This function will start an executable using Wine.
-    ///
-    ///  This function is specific to Arch Linux + X11
-    ///
-    /// Note that this will work on SteamDeck OS 3.0
-    ///
-    #[allow(unused)]
-    pub fn start_executable_arch_x11() {
-        // TODO: Ask for Wine to be installed either through the AUR or to be installed through Flatpak if a steamdeck is used
-        // TODO: Ask it through notification after launching the launcher.
-        todo!()
-    }
+///  This function is specific to Arch Linux + X11
+///
+/// Note that this will work on SteamDeck OS 3.0
+///
+#[allow(unused)]
+#[cfg(not(target_os = "windows"))]
+pub fn start_executable_arch_x11() {
+    // TODO: Ask for Wine to be installed either through the AUR or to be installed through Flatpak if a steamdeck is used
+    // TODO: Ask it through notification after launching the launcher.
+    todo!()
 }

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/process_utils.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/process_utils.rs
@@ -1,0 +1,98 @@
+//! Process utilities for finding child processes using sysinfo.
+
+use sysinfo::{Pid, ProcessesToUpdate, System};
+use tracing::debug;
+
+/// Find the first child process of a given parent PID.
+/// Returns None if no child is found.
+pub fn find_child_pid(parent_pid: u32) -> Option<u32> {
+    let mut sys = System::new();
+    // Refresh all processes to populate the process list
+    sys.refresh_processes(ProcessesToUpdate::All, true);
+
+    let parent = Pid::from_u32(parent_pid);
+
+    sys.processes()
+        .values()
+        .find(|p| p.parent() == Some(parent))
+        .map(|p| p.pid().as_u32())
+}
+
+/// Find a child process of the given parent, retrying up to max_attempts times.
+/// Waits wait_ms milliseconds between attempts.
+pub fn find_child_pid_with_retry(parent_pid: u32, max_attempts: u32, wait_ms: u64) -> Option<u32> {
+    for attempt in 1..=max_attempts {
+        if let Some(child) = find_child_pid(parent_pid) {
+            debug!(
+                "Found child PID {} for parent {} on attempt {}",
+                child, parent_pid, attempt
+            );
+            return Some(child);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(wait_ms));
+    }
+    None
+}
+
+/// Check if a PID is a descendant (child, grandchild, etc.) of an ancestor PID.
+pub fn is_descendant_of(pid: u32, ancestor_pid: u32) -> bool {
+    let mut sys = System::new();
+    // Refresh all processes to populate the process list
+    sys.refresh_processes(ProcessesToUpdate::All, true);
+
+    let mut current = Pid::from_u32(pid);
+    let ancestor = Pid::from_u32(ancestor_pid);
+
+    // Walk up the parent chain
+    for _ in 0..10 {
+        if let Some(process) = sys.process(current) {
+            if let Some(parent) = process.parent() {
+                if parent == ancestor {
+                    return true;
+                }
+                current = parent;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    false
+}
+
+#[cfg(target_os = "windows")]
+pub fn is_running_as_admin() -> bool {
+    use windows::Win32::{
+        Foundation::{CloseHandle, HANDLE},
+        Security::{GetTokenInformation, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation},
+        System::Threading::{GetCurrentProcess, OpenProcessToken},
+    };
+
+    unsafe {
+        let processhandle = GetCurrentProcess();
+        let mut tokenhandle = HANDLE(std::ptr::null_mut());
+        let desiredaccess = TOKEN_QUERY;
+        if OpenProcessToken(processhandle, desiredaccess, &mut tokenhandle as _).is_err() {
+            return false;
+        }
+
+        let mut tokeninformation = TOKEN_ELEVATION::default();
+        let mut needed = 0_u32;
+
+        let result = GetTokenInformation(
+            tokenhandle,
+            TokenElevation,
+            Some(&mut tokeninformation as *mut _ as _),
+            std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+            &mut needed as _,
+        )
+        .map(|_| tokeninformation.TokenIsElevated != 0);
+
+        let _ = CloseHandle(tokenhandle);
+
+        result
+    }
+    .unwrap_or_default()
+}

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/winevents/events.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/winevents/events.rs
@@ -1,0 +1,432 @@
+#[cfg(target_os = "windows")]
+pub mod win_events {
+    use serde::Serialize;
+    use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, Ordering};
+    use std::sync::mpsc;
+    use tauri::Emitter;
+    use tracing::{info, warn};
+    use uuid::Uuid;
+
+    /// Payload for hook lifecycle events
+    #[derive(Serialize, Clone, Debug)]
+    pub struct HookEvent {
+        pub id: String,
+        pub success: bool,
+        pub install_path: Option<String>,
+    }
+
+    // Store the app handle and job ID globally for emitting events
+    static GLOBAL_APP_HANDLE: AtomicPtr<tauri::AppHandle> = AtomicPtr::new(std::ptr::null_mut());
+    static GLOBAL_JOB_ID: AtomicPtr<String> = AtomicPtr::new(std::ptr::null_mut());
+    static GLOBAL_INSTALL_PATH: AtomicPtr<String> = AtomicPtr::new(std::ptr::null_mut());
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum InstallPhase {
+        SelectLanguage,
+        Welcome,
+        Information,
+        SelectDestination,
+        SelectComponents,
+        Preparing,
+        Extracting,
+        Unpacking,
+        Finalizing,
+        Completed,
+        Failed,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct ComponentInfo {
+        pub name: String,
+        pub selected: bool,
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum InstallEvent {
+        Phase { phase: InstallPhase },
+        Progress { percent: f32 },
+        File { path: String },
+        GameTitle { title: String },
+        InstallPath { path: String },
+        Components { list: Vec<ComponentInfo> },
+        DiskSpace { required_mb: f64 },
+        Closed,
+    }
+
+    pub fn parse_title_percent(title: &str) -> Option<f32> {
+        let pct_pos = title.find('%')?;
+        let before = &title[..pct_pos];
+        let start = before
+            .rfind(|c: char| !c.is_ascii_digit() && c != '.')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        before[start..].parse().ok()
+    }
+
+    fn parse_game_title(title: &str) -> Option<String> {
+        if title.starts_with("Setup - ") && !title.contains('%') {
+            let game = title.strip_prefix("Setup - ")?;
+            if !game.is_empty() && !game.to_lowercase().contains("install") {
+                return Some(game.to_string());
+            }
+        }
+        None
+    }
+
+    pub fn parse_window_title(title: &str) -> Option<InstallEvent> {
+        let title = title.trim();
+        if title.is_empty() {
+            return None;
+        }
+
+        let lower = title.to_lowercase();
+
+        if let Some(percent) = parse_title_percent(title) {
+            return Some(InstallEvent::Progress { percent });
+        }
+
+        // File path like "C:\Games\..."
+        if title.len() > 3
+            && title.chars().nth(1) == Some(':')
+            && title.chars().nth(2) == Some('\\')
+        {
+            return Some(InstallEvent::File {
+                path: title.to_string(),
+            });
+        }
+
+        if let Some(game_title) = parse_game_title(title) {
+            return Some(InstallEvent::GameTitle { title: game_title });
+        }
+
+        if lower == "setup" {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::SelectLanguage,
+            });
+        }
+
+        if lower == "information" || lower.contains("please read") {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::Information,
+            });
+        }
+
+        if lower.contains("where should") && lower.contains("be installed") {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::SelectDestination,
+            });
+        }
+
+        if lower.contains("which components") {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::SelectComponents,
+            });
+        }
+
+        if lower.contains("preparing to install") || lower.contains("ready to install") {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::Preparing,
+            });
+        }
+
+        if lower.contains("please wait while setup installs")
+            || lower.contains("extracting files")
+            || lower == "installing"
+        {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::Extracting,
+            });
+        }
+
+        if lower == "unpacking" || lower == "unpacking..." {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::Unpacking,
+            });
+        }
+
+        // Finalization phase - FitGirl repacks show "Finalization..." or similar
+        if lower.contains("saving uninstall")
+            || lower.contains("finalization")
+            || lower == "finalizing"
+            || lower == "finalizing..."
+        {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::Finalizing,
+            });
+        }
+
+        // Completed phase - installation finished successfully
+        if lower.contains("completing")
+            || lower.contains("setup has finished")
+            || lower.contains("installation complete")
+            || lower.contains("setup wizard")
+            || lower.contains("finish")
+            || lower.contains("successfully installed")
+            || (lower.contains("completed") && !lower.contains("not completed"))
+        // FitGirl specific: after finalization, the title often goes back to game name
+        // which means installation is done - but we handle that via 100% progress check
+        {
+            return Some(InstallEvent::Phase {
+                phase: InstallPhase::Completed,
+            });
+        }
+
+        None
+    }
+
+    // Global state required because SetWinEventHook callback can't capture closures
+    static GLOBAL_SENDER: AtomicPtr<mpsc::Sender<InstallEvent>> =
+        AtomicPtr::new(std::ptr::null_mut());
+    static MONITOR_ALL_PROCESSES: AtomicBool = AtomicBool::new(false);
+    static HOOK_FAILED: AtomicBool = AtomicBool::new(false);
+
+    /// Start monitoring with app_handle to emit Tauri events directly
+    pub fn monitor_install_events_with_handle(
+        app_handle: tauri::AppHandle,
+        job_id: Uuid,
+        process_id: u32,
+        install_path: Option<String>,
+    ) -> Result<mpsc::Receiver<InstallEvent>, String> {
+        // Store app_handle and job_id for later use
+        let handle_ptr = Box::into_raw(Box::new(app_handle.clone()));
+        let old_handle = GLOBAL_APP_HANDLE.swap(handle_ptr, Ordering::SeqCst);
+        if !old_handle.is_null() {
+            unsafe {
+                drop(Box::from_raw(old_handle));
+            }
+        }
+
+        let id_str = job_id.to_string();
+        let id_ptr = Box::into_raw(Box::new(id_str));
+        let old_id = GLOBAL_JOB_ID.swap(id_ptr, Ordering::SeqCst);
+        if !old_id.is_null() {
+            unsafe {
+                drop(Box::from_raw(old_id));
+            }
+        }
+
+        // Store install path for later use
+        if let Some(ref p) = install_path {
+            info!("Storing install path in global: {}", p);
+        } else {
+            warn!("No install path provided to monitor");
+        }
+
+        let path_ptr = install_path
+            .map(|p| Box::into_raw(Box::new(p)))
+            .unwrap_or(std::ptr::null_mut());
+        let old_path = GLOBAL_INSTALL_PATH.swap(path_ptr, Ordering::SeqCst);
+        if !old_path.is_null() {
+            unsafe {
+                drop(Box::from_raw(old_path));
+            }
+        }
+
+        // Reset failure flag
+        HOOK_FAILED.store(false, Ordering::SeqCst);
+
+        monitor_install_events_internal(process_id, true)
+    }
+
+    pub fn monitor_install_events(process_id: u32) -> Result<mpsc::Receiver<InstallEvent>, String> {
+        monitor_install_events_internal(process_id, false)
+    }
+
+    fn monitor_install_events_internal(
+        process_id: u32,
+        emit_events: bool,
+    ) -> Result<mpsc::Receiver<InstallEvent>, String> {
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::UI::Accessibility::{HWINEVENTHOOK, SetWinEventHook, UnhookWinEvent};
+        use windows::Win32::UI::WindowsAndMessaging::{
+            DispatchMessageW, MSG, PM_REMOVE, PeekMessageW, TranslateMessage,
+            WINEVENT_OUTOFCONTEXT, WINEVENT_SKIPOWNPROCESS,
+        };
+
+        const EVENT_OBJECT_NAMECHANGE: u32 = 0x800C;
+
+        let (tx, rx) = mpsc::channel();
+        let tx_ptr = Box::into_raw(Box::new(tx));
+        GLOBAL_SENDER.store(tx_ptr, Ordering::SeqCst);
+        MONITOR_ALL_PROCESSES.store(process_id == 0, Ordering::SeqCst);
+
+        std::thread::spawn(move || {
+            unsafe extern "system" fn event_callback(
+                _hook: HWINEVENTHOOK,
+                event: u32,
+                hwnd: HWND,
+                id_object: i32,
+                _id_child: i32,
+                _event_thread: u32,
+                _event_time: u32,
+            ) {
+                use windows::Win32::UI::WindowsAndMessaging::GetWindowTextW;
+
+                const EVENT_OBJECT_NAMECHANGE: u32 = 0x800C;
+
+                let tx_ptr = GLOBAL_SENDER.load(Ordering::SeqCst);
+                if tx_ptr.is_null() {
+                    return;
+                }
+                let tx = unsafe { &*tx_ptr };
+
+                if event == EVENT_OBJECT_NAMECHANGE && id_object == 0 {
+                    let mut buf = [0u16; 512];
+                    let len = unsafe { GetWindowTextW(hwnd, &mut buf) };
+                    if len > 0 {
+                        let title = String::from_utf16_lossy(&buf[..len as usize]);
+
+                        // Check if this looks like a setup window
+                        // Include "Finalization" for the final phase detection
+                        if title.contains("Setup")
+                            || title.contains("%")
+                            || title.contains("Finalization")
+                        {
+                            if let Some(event) = parse_window_title(&title) {
+                                let _ = tx.send(event);
+                            }
+                        }
+                    }
+                }
+            }
+
+            unsafe {
+                let target_pid = if MONITOR_ALL_PROCESSES.load(Ordering::SeqCst) {
+                    0
+                } else {
+                    process_id
+                };
+
+                let hook = SetWinEventHook(
+                    EVENT_OBJECT_NAMECHANGE,
+                    EVENT_OBJECT_NAMECHANGE,
+                    None,
+                    Some(event_callback),
+                    target_pid,
+                    0,
+                    WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS,
+                );
+
+                if hook.is_invalid() {
+                    warn!("Failed to set SetWinEventHook");
+                    return;
+                }
+
+                info!(
+                    "WinEvents hook active (SetWinEventHook) - listening for window title changes"
+                );
+
+                // Emit setup::hook::started event
+                if emit_events {
+                    let handle_ptr = GLOBAL_APP_HANDLE.load(Ordering::SeqCst);
+                    let id_ptr = GLOBAL_JOB_ID.load(Ordering::SeqCst);
+                    if !handle_ptr.is_null() && !id_ptr.is_null() {
+                        let handle = &*handle_ptr;
+                        let id = &*id_ptr;
+                        let _ = handle.emit(
+                            "setup::hook::started",
+                            HookEvent {
+                                id: id.clone(),
+                                success: true,
+                                install_path: None,
+                            },
+                        );
+                    }
+                }
+
+                let mut msg = MSG::default();
+                loop {
+                    while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
+                        let _ = TranslateMessage(&msg);
+                        DispatchMessageW(&msg);
+                    }
+
+                    if GLOBAL_SENDER.load(Ordering::SeqCst).is_null() {
+                        break;
+                    }
+
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+
+                let _ = UnhookWinEvent(hook);
+                info!("WinEvents hook stopped");
+
+                // Emit setup::hook::stopped event
+                if emit_events {
+                    let handle_ptr = GLOBAL_APP_HANDLE.load(Ordering::SeqCst);
+                    let id_ptr = GLOBAL_JOB_ID.load(Ordering::SeqCst);
+                    let path_ptr = GLOBAL_INSTALL_PATH.load(Ordering::SeqCst);
+                    if !handle_ptr.is_null() && !id_ptr.is_null() {
+                        let handle = &*handle_ptr;
+                        let id = &*id_ptr;
+                        let failed = HOOK_FAILED.load(Ordering::SeqCst);
+                        let install_path = if !path_ptr.is_null() {
+                            let p = (*path_ptr).clone();
+                            info!("Emitting stopped event with install_path: {}", p);
+                            Some(p)
+                        } else {
+                            warn!("Emitting stopped event with NO install_path");
+                            None
+                        };
+                        let _ = handle.emit(
+                            "setup::hook::stopped",
+                            HookEvent {
+                                id: id.clone(),
+                                success: !failed,
+                                install_path,
+                            },
+                        );
+                    }
+                }
+
+                let tx_ptr = GLOBAL_SENDER.swap(std::ptr::null_mut(), Ordering::SeqCst);
+                if !tx_ptr.is_null() {
+                    drop(Box::from_raw(tx_ptr));
+                }
+            }
+        });
+
+        Ok(rx)
+    }
+
+    /// Mark the hook as failed (cancelled/timeout) before stopping
+    pub fn mark_hook_failed() {
+        HOOK_FAILED.store(true, Ordering::SeqCst);
+    }
+
+    /// Check if the hook was marked as failed
+    pub fn was_hook_failed() -> bool {
+        HOOK_FAILED.load(Ordering::SeqCst)
+    }
+
+    /// Reset failure flag (call before starting new monitor)
+    pub fn reset_hook_state() {
+        HOOK_FAILED.store(false, Ordering::SeqCst);
+    }
+
+    pub fn stop_monitor() {
+        let tx_ptr = GLOBAL_SENDER.swap(std::ptr::null_mut(), Ordering::SeqCst);
+        if !tx_ptr.is_null() {
+            unsafe {
+                drop(Box::from_raw(tx_ptr));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_parse_title_percent() {
+        use super::win_events::parse_title_percent;
+
+        assert_eq!(parse_title_percent("Setup - 45.2%"), Some(45.2));
+        assert_eq!(parse_title_percent("50%"), Some(50.0));
+        assert_eq!(
+            parse_title_percent("Installing: 99.9% complete"),
+            Some(99.9)
+        );
+        assert_eq!(parse_title_percent("No percent here"), None);
+    }
+}

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/winevents/mod.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/winevents/mod.rs
@@ -1,0 +1,2 @@
+pub mod events;
+pub use events::*;

--- a/src-tauri/local-crates/fit-launcher-ui-automation/tests/test_install.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/tests/test_install.rs
@@ -1,0 +1,153 @@
+//! Test for event-driven installer progress monitoring.
+//! Run with: cargo run --example test_install -p fit-launcher-ui-automation
+
+use std::path::Path;
+use std::time::Duration;
+
+fn main() {
+    // Initialize tracing for console output
+    tracing_subscriber::fmt::init();
+
+    // Set this to a FitGirl repack setup.exe path
+    let setup_path =
+        Path::new(r"C:\Path\To\Your\FitGirl Repack\Game Name [FitGirl Repack]\setup.exe");
+
+    if !setup_path.exists() {
+        eprintln!("setup.exe not found at: {}", setup_path.display());
+        eprintln!("Please update 'repack_dir' to point to a valid FitGirl repack folder.");
+        return;
+    }
+
+    println!("=== Event-Driven Window Title Monitor Test ===");
+    println!("Setup path: {}", setup_path.display());
+    println!();
+
+    let child = std::process::Command::new(&setup_path).spawn();
+
+    match child {
+        Ok(child) => {
+            let root_pid = child.id();
+            println!("Spawned root PID: {}", root_pid);
+
+            // Wait a bit for child process to spawn
+            std::thread::sleep(Duration::from_secs(2));
+
+            // Try to find child process
+            let child_pid = fit_launcher_ui_automation::process_utils::find_child_pid(root_pid);
+            println!("Child PID: {:?}", child_pid);
+            println!();
+
+            // Use the child PID if found, otherwise use 0 (all processes)
+            let monitor_pid = child_pid.unwrap_or(0);
+            println!("Monitoring PID: {} (0 = all processes)", monitor_pid);
+            println!();
+
+            use fit_launcher_ui_automation::mighty::automation::win32::{
+                find_completed_setup, kill_process_by_pid,
+            };
+            use fit_launcher_ui_automation::winevents::win_events::{
+                InstallEvent, InstallPhase, monitor_install_events,
+            };
+
+            match monitor_install_events(monitor_pid) {
+                Ok(rx) => {
+                    let mut current_phase: Option<InstallPhase> = None;
+                    let mut last_file: Option<String> = None;
+
+                    println!("Hook started, waiting for events...");
+                    println!();
+
+                    loop {
+                        match rx.recv_timeout(Duration::from_secs(60)) {
+                            Ok(event) => match event {
+                                InstallEvent::Phase { phase } => {
+                                    if current_phase.as_ref() != Some(&phase) {
+                                        println!("[PHASE    ] {:?}", phase);
+
+                                        // Handle Finalizing phase - check for success text
+                                        if matches!(phase, InstallPhase::Finalizing) {
+                                            println!(
+                                                "[INFO     ] Detected Finalizing, checking for success..."
+                                            );
+                                            std::thread::sleep(Duration::from_millis(500));
+
+                                            if find_completed_setup() {
+                                                println!(
+                                                    "[SUCCESS  ] Found 'Setup has finished installing' text!"
+                                                );
+                                                println!("[ACTION   ] Killing processes...");
+                                                if let Some(pid) = child_pid {
+                                                    kill_process_by_pid(pid);
+                                                }
+                                                kill_process_by_pid(root_pid);
+                                                break;
+                                            } else {
+                                                println!(
+                                                    "[FAILURE  ] Success text not found - installation failed"
+                                                );
+                                                if let Some(pid) = child_pid {
+                                                    kill_process_by_pid(pid);
+                                                }
+                                                kill_process_by_pid(root_pid);
+                                                break;
+                                            }
+                                        }
+
+                                        current_phase = Some(phase);
+                                    }
+                                }
+                                InstallEvent::Progress { percent } => {
+                                    println!("[PROGRESS ] {:.1}%", percent);
+                                }
+                                InstallEvent::File { path } => {
+                                    if last_file.as_ref() != Some(&path) {
+                                        println!("[FILE     ] {}", path);
+                                        last_file = Some(path);
+                                    }
+                                }
+                                InstallEvent::GameTitle { title } => {
+                                    println!("[GAME     ] {}", title);
+                                    if current_phase.as_ref() != Some(&InstallPhase::Welcome) {
+                                        println!("[PHASE    ] Welcome");
+                                        current_phase = Some(InstallPhase::Welcome);
+                                    }
+                                }
+                                InstallEvent::InstallPath { path } => {
+                                    println!("[PATH     ] {}", path);
+                                }
+                                InstallEvent::Components { list } => {
+                                    println!("[COMPONENTS]");
+                                    for comp in list {
+                                        let status = if comp.selected { "+" } else { "-" };
+                                        println!("  [{}] {}", status, comp.name);
+                                    }
+                                }
+                                InstallEvent::DiskSpace { required_mb } => {
+                                    println!("[DISKSPACE] {:.1} MB", required_mb);
+                                }
+                                InstallEvent::Closed => {
+                                    println!("[CLOSED   ]");
+                                    break;
+                                }
+                            },
+                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                                println!("(timeout - no events for 60s)");
+                            }
+                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                                println!("(channel disconnected)");
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Failed to set up monitor: {}", e);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to spawn: {}", e);
+            eprintln!("Note: setup.exe may require admin privileges.");
+        }
+    }
+}

--- a/src/api/installer/api.ts
+++ b/src/api/installer/api.ts
@@ -1,29 +1,37 @@
 import { message } from "@tauri-apps/plugin-dialog";
 import { GlobalSettingsApi } from "../settings/api";
 import { commands, Job } from "../../bindings";
-import { listen } from "@tauri-apps/api/event";
+import { listen, emit } from "@tauri-apps/api/event";
 import { LibraryApi } from "../library/api";
 
+/**
+ * Event-driven installer service using WinEvents hooks.
+ * Flow: setup::hook::started -> setup::hook::stopped (success: true/false)
+ */
 class InstallerService {
   private started = false;
   private installedGames = new Set<string>();
-
-  // setupId -> jobId
-  private jobSetupMap = new Map<string, string>();
-
-  private progressCallbacks: Map<string, (percentage: number) => void> =
-    new Map();
-
-  findSetupIdByJobId(jobId: string): string | undefined {
-    for (const [setupId, jId] of this.jobSetupMap.entries()) {
-      if (jId === jobId) return setupId;
-    }
-    return undefined;
-  }
+  private activeInstalls = new Map<string, Job>();
+  private pendingJobs = new Map<string, Job>();
+  private failedInstalls = new Set<string>();
+  private installingJobs = new Set<string>();
 
   start() {
     if (this.started) return;
     this.started = true;
+
+    listen("setup::hook::started", (event) => {
+      const payload = event.payload as { id: string; success: boolean };
+
+      for (const [jobId, job] of this.pendingJobs.entries()) {
+        this.activeInstalls.set(payload.id, job);
+        this.installingJobs.add(job.id);
+        this.pendingJobs.delete(jobId);
+        console.log(`[Installer] Hook started: ${job.game.title}`);
+        emit("installer::state::changed", { jobId: job.id, state: "installing" });
+        break;
+      }
+    });
 
     listen("download::job_completed", async (event) => {
       const job = event.payload as Job;
@@ -35,150 +43,170 @@ class InstallerService {
       )
         return;
 
-      console.log("Installing game:", job.game.title);
       this.installedGames.add(job.id);
       await this.handle(job);
     });
 
-    listen("setup::progress::updated", (event) => {
-      const payload = event.payload as { id: string; percentage: number };
-      this.progressCallbacks.get(payload.id)?.(payload.percentage);
-    });
+    listen("setup::hook::stopped", async (event) => {
+      const payload = event.payload as { id: string; success: boolean; install_path?: string };
 
-    listen("setup::progress::finished", async (event) => {
-      const payload = event.payload as { id: string; percentage: number };
+      const job = this.activeInstalls.get(payload.id);
+      if (!job) return;
 
-      console.log(`Installation finished for ${payload.id}`);
-      this.progressCallbacks.delete(payload.id);
+      console.log(`[Installer] Hook stopped: ${job.game.title}, success=${payload.success}`);
+      this.installingJobs.delete(job.id);
 
-      // Cleanup: setupId -> jobId
-      const jobId = this.jobSetupMap.get(payload.id);
-      if (jobId) {
-        await commands.dmCleanJob(jobId, payload.id);
-        this.jobSetupMap.delete(payload.id);
+      if (payload.success) {
+        try {
+          console.log("[Installer] Processing successful installation:", job.game.title);
+
+          const settings = await GlobalSettingsApi.getInstallationSettings();
+          const lib_api = new LibraryApi();
+          const dwlnd_game = lib_api.gameToDownloadedGame(job.game);
+
+          if (payload.install_path) {
+            try {
+              const exePath = await commands.findGameExecutable(payload.install_path);
+              if (exePath) {
+                const execInfo = await commands.executableInfoDiscovery(exePath, payload.install_path);
+                if (execInfo) {
+                  dwlnd_game.executable_info = execInfo;
+                  dwlnd_game.installation_info = {
+                    output_folder: payload.install_path,
+                    download_folder: job.job_path,
+                    file_list: [],
+                  };
+                }
+              }
+            } catch (err) {
+              console.error("[Installer] Error finding game executable:", err);
+            }
+          }
+
+          await lib_api.addDownloadedGame(dwlnd_game);
+
+          if (settings.auto_clean) {
+            await commands.dmRemove(job.id);
+          }
+          await commands.dmCleanJob(job.id, payload.id);
+
+          console.log("[Installer] Complete:", job.game.title);
+          emit("installer::state::changed", { jobId: job.id, state: "success" });
+        } catch (err) {
+          console.error("[Installer] Error in success handler:", err);
+        }
+      } else {
+        this.failedInstalls.add(job.id);
+        emit("installer::state::changed", { jobId: job.id, state: "failed" });
       }
+
+      this.activeInstalls.delete(payload.id);
     });
-
-    listen("setup::progress::cancelled", (event) => {
-      const payload = event.payload as { id: string; percentage: number };
-      console.warn(
-        `Installation cancelled for ${payload.id} at ${payload.percentage}%`
-      );
-
-      this.progressCallbacks.delete(payload.id);
-    });
-  }
-
-  onProgress(jobId: string, callback: (percentage: number) => void) {
-    this.progressCallbacks.set(jobId, callback);
   }
 
   async handle(job: Job) {
     const settings = await GlobalSettingsApi.getInstallationSettings();
     if (!settings.auto_install) return;
 
+    this.pendingJobs.set(job.id, job);
+
     try {
       let result;
 
       if (job.source === "Torrent") {
         result = await commands.dmRunAutomateSetupInstall(job);
-        console.log("Starting installation for:", job.game.title);
 
-        if (result.status === "error" && result.error === "AdminModeError") {
-          await message(
-            "Installation requires administrator privileges.\nPlease restart FitLauncher as administrator.",
-            { title: "Administrator Rights Required", kind: "error" }
-          );
-        }
-
-        if (result.status === "ok") {
-          // result.data = setupId
-          this.jobSetupMap.set(result.data, job.id);
+        if (result.status === "error") {
+          this.pendingJobs.delete(job.id);
+          if (result.error === "AdminModeError") {
+            await message(
+              "Installation requires administrator privileges.\nPlease restart FitLauncher as administrator.",
+              { title: "Administrator Rights Required", kind: "error" }
+            );
+          }
+          return;
         }
       } else {
         result = await commands.dmExtractAndInstall(job, settings.auto_clean);
 
         if (result.status === "error") {
-          const err = result.error;
-
-          if (typeof err === "object" && "InstallationError" in err) {
-            const installErr = err.InstallationError;
-
-            if (installErr === "AdminModeError") {
-              await message(
-                "Installation requires administrator privileges.\nPlease restart FitLauncher as administrator.",
-                { title: "Administrator Rights Required", kind: "error" }
-              );
-            } else if (
-              typeof installErr === "object" &&
-              "IOError" in installErr
-            ) {
-              await message(
-                `Installation failed due to an IO error:\n${installErr.IOError}`,
-                { title: "IO Error", kind: "error" }
-              );
-            } else {
-              await message("An unknown installation error occurred.", {
-                title: "Installation Error",
-                kind: "error",
-              });
-            }
-          } else if (typeof err === "object" && "Io" in err) {
-            await message(`A general IO error occurred:\n${err.Io}`, {
-              title: "IO Error",
-              kind: "error",
-            });
-          } else if (typeof err === "object" && "Unrar" in err) {
-            await message(`Failed to extract archive:\n${err.Unrar}`, {
-              title: "Extraction Error",
-              kind: "error",
-            });
-          } else if (err === "NoParentDirectory") {
-            await message(
-              "Extraction failed because the parent directory doesn't exist.",
-              { title: "Missing Directory", kind: "error" }
-            );
-          } else if (err === "NoRarFileFound") {
-            await message("No RAR file found in the download directory.", {
-              title: "Missing Archive File",
-              kind: "error",
-            });
-          } else {
-            await message("An unknown error occurred during extraction.", {
-              title: "Unknown Error",
-              kind: "error",
-            });
-          }
-        } else {
-          // result.data = setupId
-          this.jobSetupMap.set(result.data, job.id);
-        }
-      }
-
-      this.onProgress(job.id, (percent) => {
-        console.log(`Job ${job.id} progress: ${percent.toFixed(2)}%`);
-      });
-
-      if (result?.status === "ok") {
-        console.log("Installation completed for:", job.game.title);
-        if (settings.auto_clean) {
-          const setupId = this.findSetupIdByJobId(job.id);
-
-          if (setupId) {
-            await commands.dmRemove(job.id);
-            await commands.dmCleanJob(job.id, setupId);
-            this.jobSetupMap.delete(setupId);
-
-            let lib_api = new LibraryApi();
-            let dwlnd_game = lib_api.gameToDownloadedGame(job.game);
-
-            await lib_api.addDownloadedGame(dwlnd_game);
-          }
+          this.pendingJobs.delete(job.id);
+          await this.handleExtractError(result.error);
+          return;
         }
       }
     } catch (err) {
-      console.error("INSTALL FAILED for", job.game?.title, err);
+      this.pendingJobs.delete(job.id);
     }
+  }
+
+  private async handleExtractError(err: unknown) {
+    if (typeof err === "object" && err !== null) {
+      if ("InstallationError" in err) {
+        const installErr = (err as { InstallationError: unknown }).InstallationError;
+        if (installErr === "AdminModeError") {
+          await message(
+            "Installation requires administrator privileges.\nPlease restart FitLauncher as administrator.",
+            { title: "Administrator Rights Required", kind: "error" }
+          );
+        } else if (typeof installErr === "object" && installErr !== null && "IOError" in installErr) {
+          await message(
+            `Installation failed due to an IO error:\n${(installErr as { IOError: string }).IOError}`,
+            { title: "IO Error", kind: "error" }
+          );
+        } else {
+          await message("An unknown installation error occurred.", {
+            title: "Installation Error",
+            kind: "error",
+          });
+        }
+      } else if ("Io" in err) {
+        await message(`A general IO error occurred:\n${(err as { Io: string }).Io}`, {
+          title: "IO Error",
+          kind: "error",
+        });
+      } else if ("Unrar" in err) {
+        await message(`Failed to extract archive:\n${(err as { Unrar: string }).Unrar}`, {
+          title: "Extraction Error",
+          kind: "error",
+        });
+      }
+    } else if (err === "NoParentDirectory") {
+      await message(
+        "Extraction failed because the parent directory doesn't exist.",
+        { title: "Missing Directory", kind: "error" }
+      );
+    } else if (err === "NoRarFileFound") {
+      await message("No RAR file found in the download directory.", {
+        title: "Missing Archive File",
+        kind: "error"
+      }
+      );
+    } else {
+      await message("An unknown error occurred during extraction.", {
+        title: "Unknown Error",
+        kind: "error",
+      });
+    }
+  }
+
+  isInstallFailed(jobId: string): boolean {
+    return this.failedInstalls.has(jobId);
+  }
+
+  isInstalling(jobId: string): boolean {
+    return this.installingJobs.has(jobId);
+  }
+
+  clearFailedState(jobId: string): void {
+    this.failedInstalls.delete(jobId);
+    emit("installer::state::changed", { jobId, state: "cleared" });
+  }
+
+  async retryInstall(job: Job): Promise<void> {
+    this.clearFailedState(job.id);
+    this.installedGames.delete(job.id);
+    await this.handle(job);
   }
 }
 


### PR DESCRIPTION
## Event-Driven Installer Monitoring

Replaced the old polling-based installer progress monitoring with Windows `SetWinEventHook` API way more efficient and reliable.

### How it works

Instead of constantly polling the installer window for changes, we now register a hook with Windows that fires events whenever a window title changes. The hook is scoped to the installer's PID so we only get events from the setup process, not random windows on the system. Windows pushes events to us, we don't ask it repeatedly.

The only polling we do is ONE check at the very end when we detect "Finalization..." in the title, we verify success by looking for "Setup has finished installing" text in the window content. If found = success, if not = failed install. So in the future if you get more in depth with the UI automation youll be able to poll much more freely as you arent exhausting CPU from the preexisting 250ms polls and most importantly, you dont need to fiddle around with timings on detecting failure

I currently set the event inactivity of 60s to be treated as a failure, which is fair as the progress bar emits quite aggressively and plentifully but just keep it in mind.

Progress tracking works by parsing the window title (FitGirl installers show percentages like "45.2%" in the title bar). Phases are detected the same way titles like "Finalization..." or "Extracting files" tell us what stage we're at.

On completion we kill the installer processes automatically (child PID first, then root) so the user doesn't have to click Finish which would open unwanted browser tabs/dialogs.

### Backend changes

- Added events.rs which handles the SetWinEventHook lifecycle and event parsing
- Added process_utils.rs which is a sysinfo-based child process discovery method + moved `is_running_as_admin` here from `mighty_automation.rs`
- Flattened `mighty_automation.rs` removed the deprecated `checklist_automation` module and `windows_ui_automation` sub-module, moved contents to top level. Simplifies imports and reduces nesting
- Updated types.rs to import directly from mighty_automation instead of the removed submodule
- Changed unknown GID errors to debug level in `manager.rs` to reduce log spam
- Added filtering in `logging.rs` for aria2 websocket noise

### Frontend changes

Updated `installer/api.ts` to use the new hook lifecycle events:
- `setup::hook::started` fires when we start monitoring
- `setup::hook::stopped` with `success: bool` and `install_path` - fires when done

Downloads page now reflects install states properly with retry possibility on failure though very rudimentary as i didnt add any error state detections just if it failed or not

### Testing

Update the setup.exe path in test_intall.rs and run with admin (installer needs elevation):
```powershell
cd src-tauri; cargo run --example test_install -p fit-launcher-ui-automation
```

little bug fixes such as: fixed executable finding logic and it works now reliably, muting process now works

Tested on Windows with a couple of games and it works on my end

### Note
Whilst this PR works without the debrid PR i made https://github.com/CarrotRub/Fit-Launcher/pull/144
the other way around it doesnt, ive been on this for so long i forgot exactly why just if my memory serves me correct. whilst it might be the fact that the polling was lagging me so bad it triggered the aggressive timing. 
but i tested it and they will cause no merge conflicts with origin

example pictures
Failure to install
<img width="1708" height="116" alt="Screenshot 2025-12-03 182251" src="https://github.com/user-attachments/assets/5e951a1d-aafb-481d-9047-f37ddae788b2" />
Install
<img width="1502" height="167" alt="Screenshot 2025-12-03 182506" src="https://github.com/user-attachments/assets/75c5e518-ede1-4047-a4c5-22b04f4ce092" />
