### PR TITLE
fix: improve DNS settings UX and add a fallback mechanism to the resolver on launch

### DIFF
--- a/src-tauri/local-crates/fit-launcher-config/src/client/dns/resolver.rs
+++ b/src-tauri/local-crates/fit-launcher-config/src/client/dns/resolver.rs
@@ -1,24 +1,40 @@
 use std::{
     net::{IpAddr, SocketAddr},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
 };
 
 use hickory_resolver::{
     TokioResolver, name_server::TokioConnectionProvider, proto::xfer::Protocol,
+    system_conf::read_system_conf,
 };
+use once_cell::sync::Lazy;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::client::dns::FitLauncherDnsConfig;
 
 use hickory_resolver::config::*;
 use std::io;
 
-/// A HickoryResolver that defers creation of the actual TokioAsyncResolver.
-/// Protocol is determined from the dns config.
+/// Short timeout to avoid blocking the app when VPN providers block direct DNS (e.g., 1.1.1.1).
+const CUSTOM_DNS_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Persists across the session to avoid repeated failures when custom DNS is blocked.
+static USE_SYSTEM_DNS_FALLBACK: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+
+/// DNS resolver with automatic system fallback.
+///
+/// Many VPN providers block direct DNS queries to public resolvers like 1.1.1.1,
+/// which would cause silent failures without this fallback mechanism. Once custom
+/// DNS fails, all subsequent lookups use system DNS for the session.
 #[derive(Debug, Clone)]
 pub struct HickoryResolverWithProtocol {
-    state: Arc<once_cell::sync::OnceCell<TokioResolver>>,
+    custom_resolver: Arc<once_cell::sync::OnceCell<TokioResolver>>,
+    system_resolver: Arc<once_cell::sync::OnceCell<TokioResolver>>,
     dns_config: FitLauncherDnsConfig,
     rng: Option<rand::rngs::SmallRng>,
 }
@@ -26,7 +42,8 @@ pub struct HickoryResolverWithProtocol {
 impl HickoryResolverWithProtocol {
     pub fn new(dns_config: FitLauncherDnsConfig) -> Self {
         Self {
-            state: Arc::new(once_cell::sync::OnceCell::new()),
+            custom_resolver: Arc::new(once_cell::sync::OnceCell::new()),
+            system_resolver: Arc::new(once_cell::sync::OnceCell::new()),
             dns_config,
             rng: None,
         }
@@ -46,16 +63,39 @@ impl Resolve for HickoryResolverWithProtocol {
     fn resolve(&self, name: Name) -> Resolving {
         let mut hickory_resolver = self.clone();
         Box::pin(async move {
-            let resolver = hickory_resolver
-                .state
+            // Skip custom DNS entirely once we know it's blocked (e.g., by VPN).
+            if USE_SYSTEM_DNS_FALLBACK.load(Ordering::Relaxed) {
+                return resolve_with_system_dns(&mut hickory_resolver, &name).await;
+            }
+
+            let custom_resolver = hickory_resolver
+                .custom_resolver
                 .get_or_try_init(|| new_resolver_with_config(&hickory_resolver.dns_config))?;
 
-            let lookup = match resolver.lookup_ip(name.as_str()).await {
-                Ok(ip) => ip,
-                Err(err) => {
-                    eprintln!("Error looking up IPs: {err}");
-                    eprintln!("Name of DNS is {:?}", name.as_str());
-                    return Err(err.into());
+            let lookup_result =
+                tokio::time::timeout(CUSTOM_DNS_TIMEOUT, custom_resolver.lookup_ip(name.as_str()))
+                    .await;
+
+            let lookup = match lookup_result {
+                Ok(Ok(ip)) => ip,
+                Ok(Err(err)) => {
+                    // VPN or network is blocking custom DNS; fall back to system DNS for the session.
+                    warn!(
+                        "Custom DNS lookup failed for {}: {}. Switching to system DNS for this session.",
+                        name.as_str(),
+                        err
+                    );
+                    USE_SYSTEM_DNS_FALLBACK.store(true, Ordering::Relaxed);
+                    return resolve_with_system_dns(&mut hickory_resolver, &name).await;
+                }
+                Err(_) => {
+                    // Timeout indicates custom DNS is unreachable (common with VPNs blocking 1.1.1.1).
+                    warn!(
+                        "Custom DNS lookup timed out for {}. Switching to system DNS for this session.",
+                        name.as_str()
+                    );
+                    USE_SYSTEM_DNS_FALLBACK.store(true, Ordering::Relaxed);
+                    return resolve_with_system_dns(&mut hickory_resolver, &name).await;
                 }
             };
 
@@ -75,10 +115,57 @@ impl Resolve for HickoryResolverWithProtocol {
     }
 }
 
-/// A generalized function to create a new resolver given a `DnsConfig`.
-/// We determine the protocol and primary DNS server, then construct the resolver.
+/// Falls back to OS-configured DNS which respects VPN routing.
+async fn resolve_with_system_dns(
+    hickory_resolver: &mut HickoryResolverWithProtocol,
+    name: &Name,
+) -> Result<Addrs, Box<dyn std::error::Error + Send + Sync>> {
+    let system_resolver = hickory_resolver
+        .system_resolver
+        .get_or_try_init(new_system_resolver)?;
+
+    match system_resolver.lookup_ip(name.as_str()).await {
+        Ok(lookup) => {
+            info!("System DNS resolved {}", name.as_str());
+
+            let addrs: Addrs = if let Some(rng) = &mut hickory_resolver.rng {
+                use rand::seq::SliceRandom;
+
+                let mut ips = lookup.into_iter().collect::<Vec<_>>();
+                ips.shuffle(rng);
+
+                Box::new(ips.into_iter().map(|addr| SocketAddr::new(addr, 0)))
+            } else {
+                Box::new(lookup.into_iter().map(|addr| SocketAddr::new(addr, 0)))
+            };
+
+            Ok(addrs)
+        }
+        Err(err) => {
+            eprintln!(
+                "System DNS lookup also failed for {}: {}",
+                name.as_str(),
+                err
+            );
+            Err(err.into())
+        }
+    }
+}
+
+/// Uses OS DNS config which works through VPN tunnels.
+fn new_system_resolver() -> io::Result<TokioResolver> {
+    let (config, opts) =
+        read_system_conf().map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
+    Ok(
+        TokioResolver::builder_with_config(config, TokioConnectionProvider::default())
+            .with_options(opts)
+            .build(),
+    )
+}
+
+/// Aggressive timeouts (2s, 1 attempt) ensure fast fallback when custom DNS is blocked.
 pub fn new_resolver_with_config(dns_config: &FitLauncherDnsConfig) -> io::Result<TokioResolver> {
-    // Determine protocol
     let protocol = match dns_config.protocol.to_uppercase().as_str() {
         "UDP" => Protocol::Udp,
         "HTTPS" => Protocol::Https,
@@ -93,12 +180,9 @@ pub fn new_resolver_with_config(dns_config: &FitLauncherDnsConfig) -> io::Result
     let primary_str = dns_config.primary.clone().unwrap_or("1.1.1.1".to_string());
 
     let custom_socket_vec_addr: SocketAddr = match primary_str.parse::<SocketAddr>() {
-        Ok(socket_addr) => {
-            // Successfully parsed a SocketAddr with IP and port
-            socket_addr
-        }
+        Ok(socket_addr) => socket_addr,
         Err(_) => {
-            // Failed to parse as SocketAddr, assume it's an IP without a port (Probably an IpV4 that's custom because the struct doesn't allow custom ports for UDP)
+            // IP without port - default to standard DNS port 53.
             let primary_ip: IpAddr = primary_str
                 .parse()
                 .expect("Invalid primary DNS address in dns.json");
@@ -110,9 +194,15 @@ pub fn new_resolver_with_config(dns_config: &FitLauncherDnsConfig) -> io::Result
     let mut custom_resolver_dns_config = ResolverConfig::new();
     custom_resolver_dns_config.add_name_server(custom_name_server_config);
 
+    // Fast failure is critical - system DNS fallback handles retries.
+    let mut opts = ResolverOpts::default();
+    opts.timeout = Duration::from_secs(2);
+    opts.attempts = 1;
+
     Ok(TokioResolver::builder_with_config(
         custom_resolver_dns_config,
         TokioConnectionProvider::default(),
     )
+    .with_options(opts)
     .build())
 }

--- a/src/pages/Settings-01/Settings-Categories/Global/DNSSettings/DNSSettings.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Global/DNSSettings/DNSSettings.tsx
@@ -1,7 +1,5 @@
 import { Show } from "solid-js"
 
-import { confirm } from "@tauri-apps/plugin-dialog";
-import { exit } from "@tauri-apps/plugin-process";
 import { FitLauncherDnsConfig } from "../../../../../bindings";
 import { SettingsSectionProps } from "../../../../../types/settings/types";
 import PageGroup from "../../Components/PageGroup";
@@ -34,26 +32,12 @@ function DNSContent({
     handleTextCheckChange,
     handleSwitchCheckChange,
 }: SettingsSectionProps<FitLauncherDnsConfig>) {
-
-    async function warnDNSSystemConf() {
-        const confirm_sys = await confirm(
-            "Please remember that you will have to save first and then restart FitLauncher for the changes to be made.\nDo you want to restart now or later? (if you do not restart now, you will have to quit the app from taskbar too).\nKeep in mind that if it makes the app slow down revert to the default settings.",
-            { title: 'FitLauncher', kind: 'warning' }
-        );
-        if (confirm_sys) {
-            await exit();
-        }
-    }
-
     return (
         <>
             <LabelCheckboxSettings
                 text="Use your system's default DNS Settings:"
                 checked={settings().system_conf}
-                action={async () => {
-                    handleSwitchCheckChange?.("dns.system_conf");
-                    await warnDNSSystemConf();
-                }}
+                action={() => handleSwitchCheckChange?.("dns.system_conf")}
             />
 
             <LabelInputAddress text="Primary DNS Address" typeText="IpV4" value={settings()?.primary || "1.1.1.1"}

--- a/src/pages/Settings-01/Settings-Categories/Global/GlobalSettingsPage.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Global/GlobalSettingsPage.tsx
@@ -1,7 +1,8 @@
 import { createSignal, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import { invoke } from "@tauri-apps/api/core";
-import { message } from "@tauri-apps/plugin-dialog";
+import { confirm, message } from "@tauri-apps/plugin-dialog";
+import { relaunch } from "@tauri-apps/plugin-process";
 import CacheSettings from "./CacheSettings/CacheSettings";
 import InstallSettingsPart from "./InstallSettings/InstallSettings";
 import DNSPart from "./DNSSettings/DNSSettings";
@@ -70,6 +71,17 @@ function GlobalSettingsPage(props: { settingsPart: GlobalSettingsPart }): JSX.El
         title: "FitLauncher",
         kind: "info",
       });
+
+      // DNS changes require a restart to take effect
+      if (selectedPart() === "dns") {
+        const shouldRestart = await confirm(
+          "DNS settings require a restart to take effect.\nWould you like to restart FitLauncher now?",
+          { title: "FitLauncher", kind: "info" }
+        );
+        if (shouldRestart) {
+          await relaunch();
+        }
+      }
     } catch (error: unknown) {
       await message("Error saving settings: " + String(error), {
         title: "FitLauncher",


### PR DESCRIPTION
Remove premature restart popup on DNS setting changes and moved restart prompt to after the Save button is clicked. Use relaunch() instead of exit() for actual app restart
Added fallback to System DNS after resolve failures on launch (session wide)

fixes https://github.com/CarrotRub/Fit-Launcher/issues/146 and any related DNS issues on VPNs 