### PR TITLE
refactor: simple error refactor

### DIFF
--- a/src/Pop-Ups/Add-Local-Game-PopUp/Add-Local-Game-PopUp.tsx
+++ b/src/Pop-Ups/Add-Local-Game-PopUp/Add-Local-Game-PopUp.tsx
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import { render } from "solid-js/web";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../helpers/error";
 import { mkdir, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { invoke } from "@tauri-apps/api/core";
@@ -49,7 +50,7 @@ export default function createAddLocalGamePopup(props: AddLocalGamePopupProps) {
 
         if (props.action) await props.action(newGame);
       } else {
-        await message(`Failed to add game: ${gameResult.error.data}`, { title: "Error", kind: "error" });
+        await showError(gameResult.error.data, "Error");
       }
 
       await message("Game added to Library successfully", {
@@ -58,7 +59,7 @@ export default function createAddLocalGamePopup(props: AddLocalGamePopupProps) {
       });
 
     } catch (err) {
-      await message(`Failed to add game: ${err}`, { title: "Error", kind: "error" });
+      await showError(err, "Error");
     } finally {
       destroy();
     }

--- a/src/Pop-Ups/Basic-AddToCollection-PopUp/Basic-AddToCollection-PopUp.tsx
+++ b/src/Pop-Ups/Basic-AddToCollection-PopUp/Basic-AddToCollection-PopUp.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, onMount, Show } from "solid-js";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../helpers/error";
 import Button from "../../components/UI/Button/Button";
 import { AddToCollectionProps } from "../../types/popup";
 import { Modal } from "../Modal/Modal";
@@ -44,7 +45,7 @@ const createAddToCollectionPopup = (props: AddToCollectionProps) => {
         addedTo.push(collectionName);
         await message(`Added to ${collectionName}`, { title: "Success", kind: "info" });
       } else {
-        await message(result.error ?? "Unknown error", { title: "Error", kind: "error" });
+        await showError(result.error ?? "Unknown error", "Error");
       }
     }
 

--- a/src/Pop-Ups/Cookies-Import-PopUp/Cookies-Import-PopUp.tsx
+++ b/src/Pop-Ups/Cookies-Import-PopUp/Cookies-Import-PopUp.tsx
@@ -6,6 +6,7 @@ import { PopupProps } from "../../types/popup";
 import { Modal } from "../Modal/Modal";
 import { useDropZone } from "../../components/DropZone-01/DropZone";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../helpers/error";
 
 export default function createCookiesImportPopup(props: PopupProps<[File]>) {
     const container = document.createElement("div");
@@ -28,10 +29,7 @@ export default function createCookiesImportPopup(props: PopupProps<[File]>) {
                     setDroppedFileName(file.name);
                     setDroppedFilePath(file.webkitRelativePath);
                 } else {
-                    await message("Wrong file type", {
-                        title: "File Type Error",
-                        kind: "error",
-                    });
+                    await showError("Wrong file type", "File Type Error");
                 }
             }
         };
@@ -49,10 +47,7 @@ export default function createCookiesImportPopup(props: PopupProps<[File]>) {
                     props.action?.(new File([], fileName));
                 } else {
                     console.log("Invalid file type");
-                    await message("This isn't a JSON file.", {
-                        title: "Wrong Type",
-                        kind: "error",
-                    });
+                    await showError("This isn't a JSON file.", "Wrong Type");
                 }
             }
         });

--- a/src/Pop-Ups/Download-PopUp/Download-PopUp.tsx
+++ b/src/Pop-Ups/Download-PopUp/Download-PopUp.tsx
@@ -1,5 +1,6 @@
 import { createSignal, onMount, Show, Component, For } from "solid-js";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../helpers/error";
 import { render } from "solid-js/web";
 import {
   HardDrive,
@@ -60,10 +61,7 @@ export default function createDownloadPopup(props: DownloadPopupProps) {
       const result = await GlobalSettingsApi.setInstallationSettings(newSettings);
       if (result.status === "error") {
         console.error("Failed to update installation settings:", result.error);
-        await message("Could not save installation settings", {
-          title: "FitLauncher",
-          kind: "error",
-        });
+        await showError(result.error, "Could not save installation settings");
       }
     };
 
@@ -86,7 +84,7 @@ export default function createDownloadPopup(props: DownloadPopupProps) {
 
       } catch (error) {
         console.error("Error initializing settings:", error);
-        await message("Failed to load download settings", { title: "Error", kind: "error" });
+        await showError(error, "Failed to load download settings");
       } finally {
         setIsInitialized(true);
       }
@@ -138,10 +136,7 @@ export default function createDownloadPopup(props: DownloadPopupProps) {
                         await DownloadSettingsApi.changeDownloadSettings(updatedSettings);
                       } catch (err) {
                         console.error("Failed to update path setting:", err);
-                        await message("Failed to save download path", {
-                          title: "Error",
-                          kind: "error",
-                        });
+                        await showError("Failed to save download path", "Error");
                       }
                     }
                   }}

--- a/src/Pop-Ups/Download-PopUp/LastStep.tsx
+++ b/src/Pop-Ups/Download-PopUp/LastStep.tsx
@@ -1,4 +1,5 @@
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../helpers/error";
 import { AlertTriangle, Box, ChevronDown, ChevronRight, Download, Info, Languages, MemoryStick, X, Zap, CheckCircle, XCircle, Loader2 } from "lucide-solid";
 import { createSignal, For, onMount, Show, Component } from "solid-js";
 import { render } from "solid-js/web";
@@ -285,10 +286,7 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                 destroy();
 
             } catch (err: any) {
-                await message(`Failed: ${err.message ?? err}`, {
-                    title: "Error",
-                    kind: "error",
-                });
+                await showError(err, "Error");
                 setError(err.message ?? "Failed");
             } finally {
                 setLoading(false);
@@ -599,10 +597,7 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                 destroy();
 
             } catch (err: any) {
-                await message(`Failed: ${err.message ?? err}`, {
-                    title: "Error",
-                    kind: "error",
-                });
+                await showError(err, "Error");
                 setError(err.message ?? "Failed");
             } finally {
                 setLoading(false);

--- a/src/api/cache/api.ts
+++ b/src/api/cache/api.ts
@@ -1,4 +1,5 @@
 import { message } from "@tauri-apps/plugin-dialog";
+import { resolveError, showError } from "../../helpers/error";
 import {
   commands,
   CustomError,
@@ -124,18 +125,12 @@ export class GamesCacheApi {
         this.cache.set(key, resultTyped);
       } else {
         if (resultTyped.error.type !== "articleNotFound") {
-          await message(
-            resultTyped.error.data.toString() ?? "An unknown error occurred.",
-            {
-              title: "Fetch Error",
-              kind: "error",
-            }
+          await showError(
+            resultTyped.error.data,
+            "Fetch Error"
           );
         } else {
-          await message("Article Not Found.", {
-            title: "Fetch Error",
-            kind: "error",
-          });
+          await showError("Article Not Found.", "Fetch Error");
         }
       }
       return resultTyped;

--- a/src/api/installation/api.ts
+++ b/src/api/installation/api.ts
@@ -7,6 +7,7 @@ import {
   TorrentApiError,
 } from "../../bindings";
 import { GlobalSettingsApi } from "../settings/api";
+import { handleInstallerError } from "../../helpers/installer-error";
 
 export class InstallationApi {
   async startInstallation(job: Job): Promise<Result<string, TorrentApiError>> {
@@ -17,16 +18,7 @@ export class InstallationApi {
       const result = await commands.dmRunAutomateSetupInstall(job);
 
       if (result.status === "error") {
-        const err = result.error;
-        if (err === "AdminModeError") {
-          await message(
-            "Installation requires administrator privileges.\nPlease restart FitLauncher as administrator.",
-            {
-              title: "Administrator Rights Required",
-              kind: "error",
-            }
-          );
-        }
+        await handleInstallerError(result.error);
       }
 
       return result;
@@ -46,65 +38,7 @@ export class InstallationApi {
       );
 
       if (result.status === "error") {
-        const err = result.error;
-
-        if (typeof err === "object" && "InstallationError" in err) {
-          const installErr = err.InstallationError;
-
-          if (installErr === "AdminModeError") {
-            await message(
-              "Installation requires administrator privileges.\nPlease restart FitLauncher as administrator.",
-              {
-                title: "Administrator Rights Required",
-                kind: "error",
-              }
-            );
-          } else if (
-            typeof installErr === "object" &&
-            "IOError" in installErr
-          ) {
-            await message(
-              `Installation failed due to an IO error:\n${installErr.IOError}`,
-              {
-                title: "IO Error",
-                kind: "error",
-              }
-            );
-          } else {
-            await message("An unknown installation error occurred.", {
-              title: "Installation Error",
-              kind: "error",
-            });
-          }
-        } else if (typeof err === "object" && "Io" in err) {
-          await message(`A general IO error occurred:\n${err.Io}`, {
-            title: "IO Error",
-            kind: "error",
-          });
-        } else if (typeof err === "object" && "Unrar" in err) {
-          await message(`Failed to extract archive:\n${err.Unrar}`, {
-            title: "Extraction Error",
-            kind: "error",
-          });
-        } else if (err === "NoParentDirectory") {
-          await message(
-            "Extraction failed because the parent directory doesn't exist.",
-            {
-              title: "Missing Directory",
-              kind: "error",
-            }
-          );
-        } else if (err === "NoRarFileFound") {
-          await message("No RAR file found in the download directory.", {
-            title: "Missing Archive File",
-            kind: "error",
-          });
-        } else {
-          await message("An unknown error occurred during extraction.", {
-            title: "Unknown Error",
-            kind: "error",
-          });
-        }
+        await handleInstallerError(result.error);
       }
 
       return result;

--- a/src/api/theme/api.ts
+++ b/src/api/theme/api.ts
@@ -1,6 +1,7 @@
 import { appDataDir, join, basename, dirname } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../helpers/error";
 import {
   copyFile,
   mkdir,
@@ -106,30 +107,20 @@ export class ThemeManagerApi {
       const match = content.match(this.blockRegex);
 
       if (!match) {
-        return await message("Invalid theme block format", {
-          title: "FitLauncher",
-          kind: "error",
-        });
+        return await showError("Invalid theme block format");
       }
 
       const [_, themeName, variables] = match;
 
       if (!this.themeRegex.test(themeName)) {
-        return await message(
-          "Theme name must be lowercase, alphanumeric or hyphen, max 40 chars",
-          {
-            title: "FitLauncher",
-            kind: "error",
-          }
+        return await showError(
+          "Theme name must be lowercase, alphanumeric or hyphen, max 40 chars"
         );
       }
 
       const valid = this.requiredVars.every((v) => variables.includes(v));
       if (!valid) {
-        return await message("Missing required variables in theme", {
-          title: "FitLauncher",
-          kind: "error",
-        });
+        return await showError("Missing required variables in theme");
       }
 
       const saveDir = await join(await appDataDir(), "themes");
@@ -143,10 +134,7 @@ export class ThemeManagerApi {
       });
     } catch (e) {
       console.error("Error adding theme:", e);
-      await message("Could not add theme.", {
-        title: "FitLauncher",
-        kind: "error",
-      });
+      await showError(e, "Could not add theme");
     }
   }
 
@@ -182,10 +170,7 @@ export class ThemeManagerApi {
       });
     } catch (err) {
       console.error("Failed to remove theme:", err);
-      await message("Could not remove theme file.", {
-        title: "FitLauncher",
-        kind: "error",
-      });
+      await showError(err, "Could not remove theme file");
     }
   }
 

--- a/src/helpers/error.ts
+++ b/src/helpers/error.ts
@@ -1,0 +1,29 @@
+import { message } from "@tauri-apps/plugin-dialog";
+
+export function resolveError(error: unknown): string {
+    if (typeof error === "string") {
+        return error;
+    }
+
+    if (error instanceof Error) {
+        return error.message;
+    }
+
+    if (typeof error === "object" && error !== null && "message" in error) {
+        return (error as { message: string }).message;
+    }
+
+    try {
+        return JSON.stringify(error);
+    } catch {
+        return "An unknown error occurred";
+    }
+}
+
+export async function showError(error: unknown, title: string = "FitLauncher"): Promise<void> {
+    const errorMessage = resolveError(error);
+    await message(errorMessage, {
+        title,
+        kind: "error",
+    });
+}

--- a/src/helpers/installer-error.ts
+++ b/src/helpers/installer-error.ts
@@ -1,0 +1,66 @@
+import { message } from "@tauri-apps/plugin-dialog";
+
+export async function handleInstallerError(err: unknown) {
+    if (typeof err === "object" && err !== null) {
+        if ("InstallationError" in err) {
+            const installErr = (err as { InstallationError: unknown }).InstallationError;
+            if (installErr === "AdminModeError") {
+                await message(
+                    "Installation requires administrator privileges.\nPlease restart FitLauncher as administrator.",
+                    { title: "Administrator Rights Required", kind: "error" }
+                );
+            } else if (
+                typeof installErr === "object" &&
+                installErr !== null &&
+                "IOError" in installErr
+            ) {
+                await message(
+                    `Installation failed due to an IO error:\n${(installErr as { IOError: string }).IOError
+                    }`,
+                    { title: "IO Error", kind: "error" }
+                );
+            } else {
+                await message("An unknown installation error occurred.", {
+                    title: "Installation Error",
+                    kind: "error",
+                });
+            }
+        } else if ("Io" in err) {
+            await message(`A general IO error occurred:\n${(err as { Io: string }).Io}`, {
+                title: "IO Error",
+                kind: "error",
+            });
+        } else if ("Unrar" in err) {
+            await message(`Failed to extract archive:\n${(err as { Unrar: string }).Unrar}`, {
+                title: "Extraction Error",
+                kind: "error",
+            });
+        } else {
+            // Fallback for other objects
+            await message(`An unknown error occurred: ${JSON.stringify(err)}`, {
+                title: "Unknown Error",
+                kind: "error",
+            });
+        }
+    } else if (err === "NoParentDirectory") {
+        await message(
+            "Extraction failed because the parent directory doesn't exist.",
+            { title: "Missing Directory", kind: "error" }
+        );
+    } else if (err === "NoRarFileFound") {
+        await message("No RAR file found in the download directory.", {
+            title: "Missing Archive File",
+            kind: "error",
+        });
+    } else if (err === "AdminModeError") {
+        await message(
+            "Installation requires administrator privileges.\nPlease restart FitLauncher as administrator.",
+            { title: "Administrator Rights Required", kind: "error" }
+        );
+    } else {
+        await message("An unknown error occurred during extraction.", {
+            title: "Unknown Error",
+            kind: "error",
+        });
+    }
+}

--- a/src/pages/Library-01/CollectionList/CollectionList.tsx
+++ b/src/pages/Library-01/CollectionList/CollectionList.tsx
@@ -3,9 +3,9 @@ import { useNavigate } from "@solidjs/router";
 import { render } from "solid-js/web";
 import BasicChoicePopup from "../../../Pop-Ups/Basic-Choice-PopUp/Basic-Choice-PopUp";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../../helpers/error";
 import { commands, Game } from "../../../bindings";
 import { CollectionListProps } from "../../../types/library/type";
-import { setDownloadGamePageInfo } from "../../../components/functions/dataStoreGlobal";
 import { LibraryApi } from "../../../api/library/api";
 import { ChevronDown, ChevronUp, Trash2, X, ChevronRight } from "lucide-solid";
 import createBasicChoicePopup from "../../../Pop-Ups/Basic-Choice-PopUp/Basic-Choice-PopUp";
@@ -61,7 +61,7 @@ export default function CollectionList(props: CollectionListProps) {
             setGamesList(prev => prev.filter(g => g.title !== game.title));
             await message("Game has been removed from collection", { title: "FitLauncher", kind: "info" });
         } else {
-            await message(result.error, { title: "FitLauncher", kind: "error" });
+            await showError(result.error);
         }
     }
 
@@ -84,10 +84,7 @@ export default function CollectionList(props: CollectionListProps) {
                     kind: "info"
                 });
             } else {
-                await message(result.error, {
-                    title: "FitLauncher",
-                    kind: "error"
-                });
+                await showError(result.error);
             }
         }
 

--- a/src/pages/Library-01/GameDownloadedItem/GameDownloadedItem.tsx
+++ b/src/pages/Library-01/GameDownloadedItem/GameDownloadedItem.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, onMount, Show } from "solid-js";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../../helpers/error";
 import { Play, Settings, Star, Info, Trash2, Pin, BookmarkPlus } from "lucide-solid";
 import { DownloadedGame, Game, ExecutableInfo, commands, GameCollection } from "../../../bindings";
 import { LibraryApi } from "../../../api/library/api";
@@ -47,7 +48,7 @@ export default function GameDownloadedItem(props: {
       const info = await api.getExecutableInfo(path, folder);
       return info;
     } catch (err) {
-      await message(String(err), { title: "Error", kind: "error" });
+      await showError(err, "Error");
       return null;
     }
   };
@@ -82,7 +83,7 @@ export default function GameDownloadedItem(props: {
         try {
           await api.runExecutable(path);
         } catch (err) {
-          await message(String(err), { title: "Error", kind: "error" });
+          await showError(err, "Error");
         }
       },
     });
@@ -98,7 +99,7 @@ export default function GameDownloadedItem(props: {
       await message("The game has been deleted correctly!", { title: "FitLauncher", kind: "info" });
       props.onGameDelete?.(gameTitle);
     } else {
-      await message(`Error deleting the game: ${result.error}`, { title: "FitLauncher", kind: "error" });
+      await showError(result.error, "Error deleting the game");
     }
   }
 

--- a/src/pages/Library-01/Library.tsx
+++ b/src/pages/Library-01/Library.tsx
@@ -3,6 +3,7 @@ import { render } from "solid-js/web";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { mkdir, writeTextFile, readDir, readTextFile } from "@tauri-apps/plugin-fs";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../helpers/error";
 
 import AddLocalGamePopUp from "../../Pop-Ups/Add-Local-Game-PopUp/Add-Local-Game-PopUp";
 import CollectionList from './CollectionList/CollectionList';
@@ -55,7 +56,7 @@ function Library() {
       setCollectionList(normalizedCollections);
       setDownloadedGamesList(downloadedGames);
     } catch (err) {
-      await message(`${err}`, { title: "FitLauncher", kind: "error" });
+      await showError(err);
     }
   });
 
@@ -77,16 +78,10 @@ function Library() {
           throw res.error;
         }
       } catch (err) {
-        await message(`Error creating collection: ${err}`, {
-          title: "Collection Creation",
-          kind: "error",
-        });
+        await showError(err, "Error creating collection");
       }
     } else {
-      await message("Name too long or too short", {
-        title: "Collection Creation",
-        kind: "error",
-      });
+      await showError("Name too long or too short", "Collection Creation");
     }
   }
 

--- a/src/pages/Settings-01/Settings-Categories/Debrid/DebridSettings.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Debrid/DebridSettings.tsx
@@ -1,6 +1,7 @@
 import { createSignal, For, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import { message } from "@tauri-apps/plugin-dialog";
+import { resolveError, showError } from "../../../../helpers/error";
 import {
     Zap,
     Key,
@@ -60,9 +61,7 @@ function DebridSettingsPage(): JSX.Element {
                 setInitialized(true);
                 return true;
             } else {
-                const errorMsg = typeof result.error === "string"
-                    ? result.error
-                    : JSON.stringify(result.error);
+                const errorMsg = resolveError(result.error);
                 console.error("[Debrid] Failed to initialize credentials:", errorMsg);
                 setInitError(`Failed to initialize secure storage: ${errorMsg}`);
                 return false;
@@ -149,10 +148,7 @@ function DebridSettingsPage(): JSX.Element {
 
         // Make sure we're initialized before trying to save
         if (!initialized()) {
-            await message("Credential store not initialized. Please wait or retry.", {
-                title: "Error",
-                kind: "error"
-            });
+            await showError("Credential store not initialized. Please wait or retry.", "Error");
             return;
         }
 
@@ -179,16 +175,10 @@ function DebridSettingsPage(): JSX.Element {
                     updateProviderState(providerId, { status: statusResult.data });
                 }
             } else {
-                await message(`Failed to save API key: ${result.error}`, {
-                    title: "Error",
-                    kind: "error"
-                });
+                await showError(result.error, "Failed to save API key");
             }
         } catch (e) {
-            await message(`Error saving API key: ${e}`, {
-                title: "Error",
-                kind: "error"
-            });
+            await showError(e, "Error saving API key");
         } finally {
             updateProviderState(providerId, { loading: false });
         }
@@ -210,16 +200,10 @@ function DebridSettingsPage(): JSX.Element {
                     apiKeyInput: ""
                 });
             } else {
-                await message(`Failed to remove API key: ${result.error}`, {
-                    title: "Error",
-                    kind: "error"
-                });
+                await showError(result.error, "Failed to remove API key");
             }
         } catch (e) {
-            await message(`Error removing API key: ${e}`, {
-                title: "Error",
-                kind: "error"
-            });
+            await showError(e, "Error removing API key");
         } finally {
             updateProviderState(providerId, { loading: false });
         }

--- a/src/pages/Settings-01/Settings-Categories/Download/Download.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Download/Download.tsx
@@ -7,6 +7,7 @@ import {
 
 import { invoke } from "@tauri-apps/api/core";
 import { message } from "@tauri-apps/plugin-dialog";
+import { showError } from "../../../../helpers/error";
 import { SettingsSectionProps, DownloadSettings, DownloadSettingsPart } from "../../../../types/settings/types";
 import GeneralSettingsPart from "./General/GeneralPart";
 import Button from "../../../../components/UI/Button/Button";
@@ -30,10 +31,7 @@ function DownloadConfigurationPage(props: { settingsPart: DownloadSettingsPart }
     if (settings.status === "ok") {
       setGlobalTorrentConfig(settings.data);
     } else {
-      await message(`Error getting the download settings: ${settings.error}`, {
-        title: "FitLauncher",
-        kind: "error",
-      });
+      await showError(settings.error, "Error getting the download settings");
     }
   });
 
@@ -78,10 +76,7 @@ function DownloadConfigurationPage(props: { settingsPart: DownloadSettingsPart }
       });
     } else {
       console.error(result.error)
-      await message("Error saving settings: " + JSON.stringify(result.error), {
-        title: "FitLauncher",
-        kind: "error",
-      });
+      await showError(result.error, "Error saving settings");
     }
   };
 

--- a/src/pages/Settings-01/Settings-Categories/Global/CacheSettings/CacheSettings.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Global/CacheSettings/CacheSettings.tsx
@@ -2,11 +2,10 @@ import { createSignal } from "solid-js";
 import type { JSX } from "solid-js";
 import { invoke } from "@tauri-apps/api/core";
 import { confirm, message } from "@tauri-apps/plugin-dialog";
-import { getVersion } from "@tauri-apps/api/app";
 import PageGroup from "../../Components/PageGroup";
 import LabelButtonSettings from "../../Components/UI/LabelButton/LabelButton";
-import { makePersisted } from "@solid-primitives/storage";
 import { check } from "@tauri-apps/plugin-updater";
+import { showError } from "../../../../../helpers/error";
 
 export default function CacheSettings(): JSX.Element {
 
@@ -35,10 +34,7 @@ function CacheContent() {
           kind: "info",
         });
       } catch (error: unknown) {
-        await message(String(error), {
-          title: "FitLauncher",
-          kind: "error",
-        });
+        await showError(error);
       }
     }
   }
@@ -47,10 +43,7 @@ function CacheContent() {
     try {
       await invoke("open_logs_directory");
     } catch (error: unknown) {
-      await message(String(error), {
-        title: "FitLauncher",
-        kind: "error",
-      });
+      await showError(error);
     }
   }
 

--- a/src/pages/Settings-01/Settings-Categories/Global/GlobalSettingsPage.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Global/GlobalSettingsPage.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { confirm, message } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
 import CacheSettings from "./CacheSettings/CacheSettings";
+import { showError } from "../../../../helpers/error";
 import InstallSettingsPart from "./InstallSettings/InstallSettings";
 import DNSPart from "./DNSSettings/DNSSettings";
 import DisplayPart from "./DisplayPart/DisplayPart";
@@ -39,10 +40,7 @@ function GlobalSettingsPage(props: { settingsPart: GlobalSettingsPart }): JSX.El
 
       setGlobalSettings({ dns, installation_settings, display });
     } catch (error: unknown) {
-      await message("Error getting settings: " + String(error), {
-        title: "FitLauncher",
-        kind: "error",
-      });
+      await showError(error, "Error getting settings");
     }
   }
 
@@ -83,10 +81,7 @@ function GlobalSettingsPage(props: { settingsPart: GlobalSettingsPart }): JSX.El
         }
       }
     } catch (error: unknown) {
-      await message("Error saving settings: " + String(error), {
-        title: "FitLauncher",
-        kind: "error",
-      });
+      await showError(error, "Error saving settings");
     }
   }
 
@@ -142,10 +137,7 @@ function GlobalSettingsPage(props: { settingsPart: GlobalSettingsPart }): JSX.El
 
       window.location.reload();
     } catch (error: unknown) {
-      await message("Error resetting settings: " + String(error), {
-        title: "FitLauncher",
-        kind: "error",
-      });
+      await showError(error, "Error resetting settings");
     }
   }
 


### PR DESCRIPTION
added the definitions in installer-error.ts and error.ts helper respectively to simplify the codebase error reporting
and added actual contexts so no more [object Object] errors, now report what actually went wrong