### PR TITLE
fix(scraping): re-order games after fetch + fetch from 0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1634,6 +1634,7 @@ dependencies = [
  "serde",
  "specta",
  "tauri",
+ "tokio",
  "tracing",
 ]
 


### PR DESCRIPTION
Fixed an issue where newly added games would never fetch since it started from page 1 instead of 0

Also re-ordered games after fetch by keeping index of pages and returning it so we could sort them from most recent to least recent while keep it speed efficient.

using zip with `missing_links` is in deterministic site order and `results` is in network timing order assumed those orders matched when they didn't always do, so i just pushed the idx there so we can order them after fetch.