### PR TITLE
fix: resolved scrollTo not working on discovery page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,7 +165,7 @@ function App(props: { children: number | boolean | Node | JSX.ArrayElement | (st
               </div>
 
               <Topbar />
-              <div class="flex-1 overflow-y-auto no-scrollbar">
+              <div class="flex-1 overflow-y-auto no-scrollbar" id="scrollElement">
                 {props.children}
               </div>
 


### PR DESCRIPTION
On the Discovery tab, the window wouldn't scroll back to the top when changing the pagination page or filters. I've added a check for the OS `prefers-reduced-motion` setting to use `smooth` scrolling by default or fallback to `auto` when animations are disabled.

I've build and tested it on my Windows 10 machine. 