### PR TITLE
fix: don't ignore pipe connectivity error

### DIFF
--- a/src-tauri/local-crates/fit-launcher-installer-controller/src/ipc/server.rs
+++ b/src-tauri/local-crates/fit-launcher-installer-controller/src/ipc/server.rs
@@ -208,6 +208,7 @@ impl IpcServer {
                         break;
                     }
                     warn!("Error receiving command: {:#}", e);
+                    return Err(e);
                 }
             }
         }


### PR DESCRIPTION
fix infinite controller.log grow up.
The best solution discussed in https://github.com/tokio-rs/tracing/issues/1940https://github.com/tokio-rs/tracing/issues/1940 is not get merged yet, `tracing-appender` does not perform size rotation. though that would not prevent infinite SSD write, but make it even terrible, as full capacity cannot stop it.