### PR TITLE
fix(logging): add rolling rotation + linter fixes + crate sec bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -388,9 +388,9 @@
       }
     },
     "node_modules/@commitlint/config-validator/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2999,9 +2999,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3090,9 +3090,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3291,9 +3291,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3780,13 +3780,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -4141,9 +4138,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -5242,9 +5239,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -5477,9 +5474,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -5496,7 +5493,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6363,9 +6360,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "rand 0.9.4",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -1213,7 +1213,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1443,7 +1443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1642,7 +1642,7 @@ dependencies = [
  "directories",
  "hickory-resolver",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -1756,7 +1756,7 @@ dependencies = [
  "html-escape",
  "itertools",
  "lazy_static",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "rusqlite",
@@ -2367,7 +2367,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -2491,6 +2491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,7 +2559,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustls",
  "thiserror 2.0.17",
@@ -2572,7 +2583,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -3358,7 +3369,7 @@ dependencies = [
  "memmap2",
  "mime_guess",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "rlimit",
@@ -3429,7 +3440,7 @@ dependencies = [
  "librqbit-buffers",
  "librqbit-clone-to-owned",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "tokio",
  "tokio-util",
@@ -3457,7 +3468,7 @@ dependencies = [
  "librqbit-clone-to-owned",
  "librqbit-core",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "tokio",
@@ -3509,7 +3520,7 @@ dependencies = [
  "librqbit-buffers",
  "librqbit-core",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "tokio",
@@ -3628,11 +3639,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3993,7 +4004,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4415,7 +4426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5051,7 +5062,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -5074,7 +5085,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5125,9 +5136,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5497,7 +5508,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6677,7 +6688,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6960,7 +6971,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7448,7 +7459,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
@@ -8062,7 +8073,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,7 +78,7 @@ chrono = "0.4.38"
 
 
 # Caching
-lru = "0.16.2"
+lru = "0.18.0"
 
 # Image processing
 image = { version = "0.25.4", default-features = false, features = [
@@ -206,7 +206,7 @@ fit-launcher-game-comments = { path = "./local-crates/fit-launcher-game-comments
 
 hickory-resolver = { version = "0.25.2", features = ["https-ring"] }
 once_cell = "1.21.3"
-rand = { version = "0.9.2", features = ["small_rng"] }
+rand = { version = "0.9.4", features = ["small_rng"] }
 futures = "0.3.31"
 tokio-util = "0.7"
 

--- a/src-tauri/local-crates/fit-launcher-installer-controller/src/main.rs
+++ b/src-tauri/local-crates/fit-launcher-installer-controller/src/main.rs
@@ -43,6 +43,7 @@ pub mod utils;
 
 use std::env;
 use tracing::{Level, error, info};
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::FmtSubscriber;
 
 use crate::ipc::server::IpcServer;
@@ -54,12 +55,17 @@ fn main() {
         .join("com.fitlauncher.carrotrub")
         .join("logs");
 
-    let file_appender = tracing_appender::rolling::never(&logs_dir, "controller.log");
+    let file_appender = RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("controller")
+        .filename_suffix("log")
+        .max_log_files(7)
+        .build(&logs_dir)
+        .expect("Failed to build rolling file appender");
     let (file_writer, _guard) = tracing_appender::non_blocking(file_appender);
 
-    // Initialize logging
     let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::DEBUG)
+        .with_max_level(Level::INFO)
         .with_target(true)
         .with_thread_ids(false)
         .with_writer(file_writer)

--- a/src-tauri/local-crates/fit-launcher-library/src/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-library/src/commands.rs
@@ -400,7 +400,7 @@ pub fn find_game_executable(folder_path: String) -> Option<String> {
     }
 
     // Sort by size (larger files are more likely to be the main game exe)
-    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.1));
 
     // Return the largest exe that's not suspiciously small (< 1MB might be a launcher stub)
     for (path, size) in &candidates {

--- a/src-tauri/local-crates/fit-launcher-scraping/src/scraping.rs
+++ b/src-tauri/local-crates/fit-launcher-scraping/src/scraping.rs
@@ -145,7 +145,7 @@ pub async fn scrape_popular_games(app: AppHandle) -> Result<(), ScrapingError> {
     if !missing.is_empty() {
         info!("Fetching {} new popular games", fetched_count);
 
-        let stream = futures::stream::iter(missing.into_iter())
+        let stream = futures::stream::iter(missing)
             .map(|(idx, link, thumb)| {
                 let ah = app.clone();
                 async move {
@@ -259,7 +259,7 @@ pub async fn scrape_recently_updated(app: AppHandle) -> Result<(), ScrapingError
             missing.len()
         );
 
-        let stream = futures::stream::iter(missing.into_iter())
+        let stream = futures::stream::iter(missing)
             .map(|(idx, link)| {
                 let ah = app.clone();
                 async move {

--- a/src-tauri/local-crates/fit-launcher-scraping/src/wordpress/mod.rs
+++ b/src-tauri/local-crates/fit-launcher-scraping/src/wordpress/mod.rs
@@ -35,7 +35,7 @@ pub async fn get_game_list_wp(game_number: u8) -> Result<Vec<Game>, ScrapingErro
         })
         .await?;
 
-    let games: Vec<Game> = futures::stream::iter(posts.into_iter())
+    let games: Vec<Game> = futures::stream::iter(posts)
         .map(|post| async move { parse_game_from_wp(post) })
         .buffer_unordered(10)
         .filter_map(async move |opt| opt)
@@ -73,7 +73,7 @@ impl WpGameFetcher {
                 break;
             }
 
-            let games: Vec<Game> = futures::stream::iter(posts.into_iter())
+            let games: Vec<Game> = futures::stream::iter(posts)
                 .map(|post| async move { parse_game_from_wp(post) })
                 .buffer_unordered(10)
                 .filter_map(async move |opt| opt)
@@ -95,7 +95,7 @@ impl WpGameFetcher {
             })
             .await?;
 
-        self.recent_games = futures::stream::iter(posts.into_iter())
+        self.recent_games = futures::stream::iter(posts)
             .map(|post| async move { parse_game_from_wp(post) })
             .buffer_unordered(10)
             .filter_map(async move |opt| opt)

--- a/src-tauri/local-crates/fit-launcher-ui-automation/src/api/types.rs
+++ b/src-tauri/local-crates/fit-launcher-ui-automation/src/api/types.rs
@@ -254,55 +254,48 @@ impl InstallationJob {
                         last_event_time = std::time::Instant::now();
 
                         match &event {
-                            ControllerEvent::Progress { job_id, percent } => {
-                                if *job_id == job_id_str {
-                                    let _ = app_handle.emit("setup::progress::percent", percent);
-                                }
+                            ControllerEvent::Progress { job_id, percent }
+                                if *job_id == job_id_str =>
+                            {
+                                let _ = app_handle.emit("setup::progress::percent", percent);
                             }
-                            ControllerEvent::Phase { job_id, phase } => {
-                                if *job_id == job_id_str {
-                                    let _ = app_handle
-                                        .emit("setup::progress::phase", format!("{:?}", phase));
-                                }
+                            ControllerEvent::Phase { job_id, phase } if *job_id == job_id_str => {
+                                let _ = app_handle
+                                    .emit("setup::progress::phase", format!("{:?}", phase));
                             }
-                            ControllerEvent::File { job_id, path } => {
-                                if *job_id == job_id_str {
-                                    let _ = app_handle.emit("setup::progress::file", path);
-                                }
+                            ControllerEvent::File { job_id, path } if *job_id == job_id_str => {
+                                let _ = app_handle.emit("setup::progress::file", path);
                             }
-                            ControllerEvent::GameTitle { job_id, title } => {
-                                if *job_id == job_id_str {
-                                    let _ = app_handle.emit("setup::progress::title", title);
-                                }
+                            ControllerEvent::GameTitle { job_id, title }
+                                if *job_id == job_id_str =>
+                            {
+                                let _ = app_handle.emit("setup::progress::title", title);
                             }
                             ControllerEvent::Completed {
                                 job_id,
                                 success: ok,
                                 install_path,
                                 error,
-                            } => {
-                                if *job_id == job_id_str {
-                                    success = *ok;
-                                    install_path_received = install_path.clone();
-                                    if success {
-                                        info!("Installation completed successfully");
-                                        let _ = app_handle
-                                            .emit("setup::progress::finished", &install_path);
-                                    } else {
-                                        let msg = error.as_deref().unwrap_or("Unknown error");
-                                        error!("Installation failed: {}", msg);
-                                        let _ = app_handle.emit("setup::progress::error", msg);
-                                    }
-                                    break;
+                            } if *job_id == job_id_str => {
+                                success = *ok;
+                                install_path_received = install_path.clone();
+                                if success {
+                                    info!("Installation completed successfully");
+                                    let _ =
+                                        app_handle.emit("setup::progress::finished", &install_path);
+                                } else {
+                                    let msg = error.as_deref().unwrap_or("Unknown error");
+                                    error!("Installation failed: {}", msg);
+                                    let _ = app_handle.emit("setup::progress::error", msg);
                                 }
+                                break;
                             }
-                            ControllerEvent::Error { job_id, message } => {
-                                // Some errors might be global or specific
-                                if job_id.as_deref() == Some(&job_id_str) || job_id.is_none() {
-                                    error!("Controller error: {}", message);
-                                    let _ = app_handle.emit("setup::progress::error", message);
-                                    break;
-                                }
+                            ControllerEvent::Error { job_id, message }
+                                if job_id.as_deref() == Some(&job_id_str) || job_id.is_none() =>
+                            {
+                                error!("Controller error: {}", message);
+                                let _ = app_handle.emit("setup::progress::error", message);
+                                break;
                             }
                             ControllerEvent::ShuttingDown => {
                                 info!("Controller shutting down unexpectedly");

--- a/src-tauri/src/bootstrap/logging.rs
+++ b/src-tauri/src/bootstrap/logging.rs
@@ -1,5 +1,6 @@
 use std::{fs, sync::OnceLock};
 use tracing::info;
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{EnvFilter, prelude::*};
 
 static LOG_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
@@ -24,7 +25,13 @@ pub fn init_logging() {
         eprintln!("Failed to create settings dir {:?}: {:?}", settings_dir, e);
     }
 
-    let file_appender = tracing_appender::rolling::never(&logs_dir, "app.log");
+    let file_appender = RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("app")
+        .filename_suffix("log")
+        .max_log_files(7)
+        .build(&logs_dir)
+        .expect("Failed to build rolling file appender");
     let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
     LOG_GUARD.set(guard).unwrap();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
     "strict": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",


### PR DESCRIPTION
Introduce file_appender to stop giant IPC logs and change loglevel to INFO rather then DEBUG

fixed husky linter errors (clippy)

crates bumped 
rand from 0.9.2 -> 0.9.4 due to security risk in 0.9.2 see : 
https://osv.dev/vulnerability/RUSTSEC-2026-0097
(didn't bump major due to new API calls but the issue was solved in the >0.9.2)

lru bumped from 0.16.2 -> 0.18.0 due to security risk in 0.9.0 -> 0.16.2 see
https://osv.dev/vulnerability/RUSTSEC-2026-0002
(bumped major due to no new API calls)

Fixes https://github.com/CarrotRub/Fit-Launcher/issues/261