### PR TITLE
Queue isolation

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1783,6 +1783,7 @@ dependencies = [
  "fit-launcher-scraping",
  "fit-launcher-ui-automation",
  "fitgirl-decrypt",
+ "libc",
  "librqbit",
  "librqbit-buffers",
  "librqbit-core",

--- a/src-tauri/local-crates/fit-launcher-ddl/src/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-ddl/src/commands.rs
@@ -82,6 +82,11 @@ pub async fn extract_fuckingfast_ddl(fuckingfast_links: Vec<String>) -> Vec<Dire
                 filename,
                 size,
             });
+        } else {
+            // Surface the HTML head so the next time FF changes their page we
+            // notice without users not knowing what happened
+            let snippet: String = html.chars().take(400).collect();
+            warn!("FUCKINGFAST_DDL_REGEX miss for {filename}; head: {snippet}");
         }
     }
 

--- a/src-tauri/local-crates/fit-launcher-ddl/src/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-ddl/src/commands.rs
@@ -5,11 +5,25 @@ use crate::{
     functions::{get_all_download_links, parse_size_to_bytes},
     structs::{DirectLink, FUCKINGFAST_DDL_REGEX},
 };
-use fit_launcher_config::client::dns::CUSTOM_DNS_CLIENT;
 use futures::{StreamExt, stream::FuturesUnordered};
-use reqwest::{Method, Request};
+use reqwest::header::{ACCEPT, ACCEPT_LANGUAGE, HeaderValue, USER_AGENT};
+use reqwest::{Client, Url};
 use specta::specta;
+use std::sync::LazyLock;
 use tracing::{error, info, warn};
+
+const FUCKINGFAST_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36";
+
+static FUCKINGFAST_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .use_rustls_tls()
+        .tcp_nodelay(true)
+        .gzip(true)
+        .brotli(true)
+        .user_agent(FUCKINGFAST_UA)
+        .build()
+        .expect("Failed to build FuckingFast reqwest client")
+});
 
 #[tauri::command]
 #[specta]
@@ -18,19 +32,23 @@ pub async fn extract_fuckingfast_ddl(fuckingfast_links: Vec<String>) -> Vec<Dire
 
     for link in fuckingfast_links {
         let fut = async move {
-            let request = Request::new(
-                Method::GET,
-                link.parse().map_err(|_| anyhow::anyhow!("invalid URL"))?,
-            );
+            let url: Url = link.parse().map_err(|_| anyhow::anyhow!("invalid URL"))?;
             let mut i = 0;
             loop {
                 i += 1;
 
                 let sleep = Duration::from_millis((500 * 2_u64.pow(i)).min(4000));
-                match CUSTOM_DNS_CLIENT
-                    .read()
-                    .await
-                    .execute(request.try_clone().unwrap())
+                match FUCKINGFAST_CLIENT
+                    .get(url.clone())
+                    .header(
+                        ACCEPT,
+                        HeaderValue::from_static(
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                        ),
+                    )
+                    .header(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"))
+                    .header(USER_AGENT, HeaderValue::from_static(FUCKINGFAST_UA))
+                    .send()
                     .await
                 {
                     Err(e) if i < 5 => {

--- a/src-tauri/local-crates/fit-launcher-ddl/src/structs.rs
+++ b/src-tauri/local-crates/fit-launcher-ddl/src/structs.rs
@@ -3,8 +3,10 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::sync::LazyLock;
 
+// FF moved direct download URLs onto the dl. subdomain, and the script now
+// also calls window.open(atob(ad), '_blank') for an ad URL that we must skip.
 pub static FUCKINGFAST_DDL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"window\.open\(\"(https://fuckingfast.co/dl/[^"]*)\"\)"#).unwrap()
+    Regex::new(r#"window\.open\(\"(https://(?:dl\.)?fuckingfast\.co/dl/[^"]+)\""#).unwrap()
 });
 pub static FUCKINGFAST_SIZE_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"Size:\s*([0-9\.]+)\s*([KMGTP]?B)"#).unwrap());

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/aria2.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/aria2.rs
@@ -7,11 +7,8 @@ use fit_launcher_aria2::{
     error::Aria2Error,
 };
 use fit_launcher_torrent::{FitLauncherConfigAria2, functions::TorrentSession};
-use sha2::Digest;
 use tokio::sync::Mutex;
-use tracing::{error, info, warn};
-
-use crate::manager::DownloadManager;
+use tracing::{info, warn};
 
 /// Timeout for aria2 operations (health check uses a shorter timeout)
 const OPERATION_TIMEOUT: Duration = Duration::from_secs(15);
@@ -27,6 +24,15 @@ pub struct Aria2WsClient {
 impl Aria2WsClient {
     pub fn new(client: Arc<Mutex<Client>>, session: Arc<TorrentSession>) -> Self {
         Self { client, session }
+    }
+
+    /// True when daemon is external (can't verify) or the recorded PID still exists.
+    pub fn is_child_alive(&self) -> bool {
+        self.session.aria2_alive()
+    }
+
+    pub async fn shutdown_if_owned(&self) {
+        self.session.shutdown().await;
     }
 
     /// Check if the connection is healthy by doing a quick version call
@@ -46,7 +52,7 @@ impl Aria2WsClient {
     }
 
     /// Ensure connection is healthy, reconnecting if necessary
-    async fn ensure_connected(&self) -> Result<(), Aria2Error> {
+    pub async fn ensure_connected(&self) -> Result<(), Aria2Error> {
         if self.is_healthy().await {
             return Ok(());
         }
@@ -183,52 +189,5 @@ impl Aria2WsClient {
         list.extend(stopped);
 
         Ok(list)
-    }
-
-    /// Spawn a background polling task that feeds DownloadManager
-    pub fn spawn_status_listener(self, manager: Arc<DownloadManager>) {
-        tokio::spawn(async move {
-            let mut last_hash = String::new();
-            let mut consecutive_errors = 0u32;
-
-            loop {
-                let statuses_result = self.list_all().await;
-
-                match statuses_result {
-                    Ok(statuses) => {
-                        consecutive_errors = 0;
-                        if let Ok(serialized) = serde_json::to_string(&statuses) {
-                            let hash = format!("{:x}", sha2::Sha256::digest(serialized.as_bytes()));
-                            if hash != last_hash {
-                                last_hash = hash.clone();
-
-                                manager.on_aria2_update(statuses).await;
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        consecutive_errors += 1;
-                        error!(
-                            "Aria2 status poll error (consecutive: {}): {:?}",
-                            consecutive_errors, err
-                        );
-
-                        // If we have multiple consecutive errors, try to reconnect
-                        if consecutive_errors >= 3 {
-                            warn!(
-                                "Multiple consecutive aria2 poll errors, attempting reconnection..."
-                            );
-                            if let Err(e) = self.ensure_connected().await {
-                                error!("Failed to reconnect aria2: {:?}", e);
-                            } else {
-                                consecutive_errors = 0;
-                            }
-                        }
-                    }
-                }
-
-                tokio::time::sleep(Duration::from_millis(500)).await;
-            }
-        });
     }
 }

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/commands.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/commands.rs
@@ -20,6 +20,14 @@ pub async fn dm_all_jobs(dm: State<'_, Arc<DownloadManager>>) -> Result<Vec<Job>
 
 #[tauri::command]
 #[specta]
+pub async fn dm_aria2_status(
+    dm: State<'_, Arc<DownloadManager>>,
+) -> Result<Aria2StatusEvent, String> {
+    Ok(dm.aria2_status())
+}
+
+#[tauri::command]
+#[specta]
 pub async fn dm_add_ddl_job(
     dm: State<'_, Arc<DownloadManager>>,
     files: Vec<DirectLink>,

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/dispatch.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/dispatch.rs
@@ -1,58 +1,119 @@
-use crate::{manager::DownloadManager, types::FileStatus};
-use aria2_ws::Client;
+use crate::aria2::Aria2WsClient;
+use crate::manager::DownloadManager;
+use crate::types::Aria2ConnState;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-fn normalize(statuses: &[aria2_ws::response::Status]) -> Vec<FileStatus> {
-    statuses
-        .iter()
-        .map(|s| FileStatus {
-            gid: Some(s.gid.clone()),
-            status: s.status.clone().into(),
-            total_length: s.total_length,
-            completed_length: s.completed_length,
-            download_speed: s.download_speed,
-            upload_speed: s.upload_speed,
-            files: s.files.clone(),
-            info_hash: s.info_hash.clone(),
-        })
-        .collect()
-}
-
-/// Polls aria2 every 500ms and feeds (yum yum yum) updates to DownloadManager
-pub fn spawn_dispatcher(manager: Arc<DownloadManager>, client: Arc<tokio::sync::Mutex<Client>>) {
+/// Polls aria2 every 500ms; fast-path reconnect when PID disappears.
+pub fn spawn_dispatcher(manager: Arc<DownloadManager>, aria: Arc<Mutex<Aria2WsClient>>) {
     tokio::spawn(async move {
         info!("Dispatcher: starting aria2 poll loop");
         let mut last_hash = String::new();
+        let mut consecutive_errors: u32 = 0;
+        let mut current_state = Aria2ConnState::Reconnecting;
+        manager.emit_aria2_status(current_state, None);
 
         loop {
-            let statuses = {
-                let locked = client.lock().await;
-                match locked.tell_active().await {
-                    Ok(mut active) => {
-                        if let Ok(mut waiting) = locked.tell_waiting(0, 100).await {
-                            active.append(&mut waiting);
-                        }
-                        if let Ok(mut stopped) = locked.tell_stopped(0, 100).await {
-                            active.append(&mut stopped);
-                        }
-                        active
+            if manager.is_empty().await {
+                if current_state != Aria2ConnState::Idle {
+                    current_state = Aria2ConnState::Idle;
+                    manager.emit_aria2_status(current_state, None);
+                }
+                sleep(Duration::from_millis(500)).await;
+                continue;
+            }
+
+            // Fast path: skip RPC and respawn immediately when the PID is gone.
+            let child_alive = { aria.lock().await.is_child_alive() };
+            if !child_alive {
+                if current_state != Aria2ConnState::Reconnecting {
+                    current_state = Aria2ConnState::Reconnecting;
+                    manager.emit_aria2_status(current_state, Some("aria2c process exited".into()));
+                }
+                warn!("aria2c PID missing, respawning");
+                let reconnect_result = {
+                    let guard = aria.lock().await;
+                    guard.ensure_connected().await
+                };
+                match reconnect_result {
+                    Ok(()) => {
+                        info!("Aria2 respawn succeeded");
+                        consecutive_errors = 0;
+                        current_state = Aria2ConnState::Connected;
+                        manager.emit_aria2_status(current_state, None);
+                        manager.reconcile_after_reconnect().await;
                     }
-                    Err(err) => {
-                        error!("Error fetching aria2 tasks: {:?}", err);
-                        Vec::new()
+                    Err(e) => {
+                        error!("Aria2 respawn failed: {:?}", e);
+                        if current_state != Aria2ConnState::Disconnected {
+                            current_state = Aria2ConnState::Disconnected;
+                            manager.emit_aria2_status(current_state, Some(format!("{}", e)));
+                        }
                     }
                 }
-            };
-            let normalized = normalize(&statuses);
+                sleep(Duration::from_millis(500)).await;
+                continue;
+            }
 
-            if let Ok(serialized) = serde_json::to_string(&normalized) {
-                let hash = format!("{:x}", Sha256::digest(serialized.as_bytes()));
-                if hash != last_hash {
-                    last_hash = hash;
-                    manager.on_aria2_update(statuses).await;
+            let result = {
+                let guard = aria.lock().await;
+                guard.list_all().await
+            };
+
+            match result {
+                Ok(statuses) => {
+                    consecutive_errors = 0;
+                    if current_state != Aria2ConnState::Connected {
+                        current_state = Aria2ConnState::Connected;
+                        manager.emit_aria2_status(current_state, None);
+                    }
+                    if let Ok(serialized) = serde_json::to_string(&statuses) {
+                        let hash = format!("{:x}", Sha256::digest(serialized.as_bytes()));
+                        if hash != last_hash {
+                            last_hash = hash;
+                            manager.on_aria2_update(statuses).await;
+                        }
+                    }
+                }
+                Err(err) => {
+                    consecutive_errors += 1;
+                    error!(
+                        "Aria2 status poll error (consecutive: {}): {:?}",
+                        consecutive_errors, err
+                    );
+
+                    if consecutive_errors >= 3 {
+                        if current_state != Aria2ConnState::Reconnecting {
+                            current_state = Aria2ConnState::Reconnecting;
+                            manager.emit_aria2_status(current_state, Some(format!("{}", err)));
+                        }
+                        warn!("Multiple consecutive aria2 poll errors, reconnecting...");
+                        let reconnect_result = {
+                            let guard = aria.lock().await;
+                            guard.ensure_connected().await
+                        };
+                        match reconnect_result {
+                            Ok(()) => {
+                                info!("Aria2 reconnect succeeded");
+                                consecutive_errors = 0;
+                                current_state = Aria2ConnState::Connected;
+                                manager.emit_aria2_status(current_state, None);
+                                // Respawned daemon has no old gids; prune dead pointers and respawn orphaned jobs.
+                                manager.reconcile_after_reconnect().await;
+                            }
+                            Err(e) => {
+                                error!("Aria2 reconnect failed: {:?}", e);
+                                if current_state != Aria2ConnState::Disconnected {
+                                    current_state = Aria2ConnState::Disconnected;
+                                    manager
+                                        .emit_aria2_status(current_state, Some(format!("{}", e)));
+                                }
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/manager.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/manager.rs
@@ -505,7 +505,6 @@ impl DownloadManager {
                     && matches!(
                         job.state,
                         DownloadState::Active
-                            | DownloadState::Paused
                             | DownloadState::Waiting
                             | DownloadState::Error
                     )

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/manager.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/manager.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::RwLock as StdRwLock;
 use std::time::{Duration, Instant};
 use tauri::{Emitter, State};
 use tokio::sync::RwLock;
@@ -49,6 +50,7 @@ pub struct DownloadManager {
     pub aria_cfg: FitLauncherConfigAria2,
     /// Librqbit session owned here to regenerate metadata when needed
     torrent_session: Arc<LibrqbitSession>,
+    aria_status: StdRwLock<Aria2StatusEvent>,
 }
 
 //todo: make it DRY
@@ -85,11 +87,46 @@ impl DownloadManager {
             tauri_handle: handle,
             aria_cfg,
             torrent_session: librqbit_sess,
+            aria_status: StdRwLock::new(Aria2StatusEvent {
+                state: Aria2ConnState::Reconnecting,
+                message: None,
+            }),
         })
     }
 
     pub async fn request_save_debounced(&self) {
         self.save.request_save().await;
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.jobs.read().await.is_empty()
+    }
+
+    pub fn emit_aria2_status(&self, state: Aria2ConnState, message: Option<String>) {
+        let status = Aria2StatusEvent { state, message };
+        match self.aria_status.write() {
+            Ok(mut current) => *current = status.clone(),
+            Err(e) => *e.into_inner() = status.clone(),
+        }
+        let _ = self.tauri_handle.emit("download::aria2_status", status);
+    }
+
+    pub fn aria2_status(&self) -> Aria2StatusEvent {
+        self.aria_status
+            .read()
+            .map(|s| s.clone())
+            .unwrap_or_else(|e| e.into_inner().clone())
+    }
+
+    pub fn emit_manager_error(&self, kind: &str, message: String, job_id: Option<String>) {
+        let _ = self.tauri_handle.emit(
+            "download::manager_error",
+            ManagerErrorEvent {
+                kind: kind.to_string(),
+                message,
+                job_id,
+            },
+        );
     }
 
     /// Emit job_updated event only if enough time has passed since last emission
@@ -121,7 +158,7 @@ impl DownloadManager {
     pub async fn load_from_disk(self: &Arc<Self>) -> Result<()> {
         let map = load_jobs(&self.persist_path).await.context("load jobs")?;
 
-        {
+        let restored_jobs: Vec<Job> = {
             let mut jobs_lock = self.jobs.write().await;
             let mut idx_lock = self.gid_index.write().await;
             let mut idx_hash = self.infohash_index.write().await;
@@ -144,9 +181,18 @@ impl DownloadManager {
 
                 jobs_lock.insert(id.clone(), job);
             }
-        }
 
-        info!("Loaded {} jobs from disk", self.jobs.read().await.len());
+            jobs_lock.values().cloned().collect()
+        };
+
+        info!("Loaded {} jobs from disk", restored_jobs.len());
+
+        for job in restored_jobs.iter() {
+            let _ = self.tauri_handle.emit("download::job_updated", job.clone());
+        }
+        let _ = self
+            .tauri_handle
+            .emit("download::manager_ready", restored_jobs.len());
 
         {
             let dm = Arc::clone(self);
@@ -348,7 +394,10 @@ impl DownloadManager {
             if let Some(job) = jobs.get_mut(job_id) {
                 let g = job.gids.clone();
                 job.state = DownloadState::Paused;
-                job.status = None;
+                // Keep last status; clearing strands the job at 0% if its gid drops off tell_active.
+                if let Some(s) = job.status.as_mut() {
+                    s.state = DownloadState::Paused;
+                }
                 job.metadata.updated_at = Utc::now();
                 let snap = job.clone();
 
@@ -364,27 +413,128 @@ impl DownloadManager {
         }
 
         if let Some(gids) = gids {
+            let mut dead_gids: Vec<Gid> = Vec::new();
             for gid in gids {
                 let aria_guard = self.aria.lock().await;
                 if let Err(e) = aria_guard.pause(&gid).await {
-                    error!("aria pause failed for gid {}: {:?}", gid, e);
+                    let msg = e.to_string();
+                    // Daemon restart leaves stale gids; prune silently instead of toasting.
+                    if msg.contains("is not found") {
+                        debug!("pause: gid {} no longer in aria2, pruning", gid);
+                        dead_gids.push(gid);
+                    } else if msg.contains("cannot be paused now") {
+                        // gid is alive but already in a non-pausable state (complete, paused, errored).
+                        debug!("pause: gid {} not pausable, skipping", gid);
+                    } else {
+                        error!("aria pause failed for gid {}: {:?}", gid, e);
+                        self.emit_manager_error(
+                            "pause",
+                            format!("Pause failed for gid {}: {}", gid, e),
+                            Some(job_id.to_string()),
+                        );
+                    }
                 }
+            }
+
+            if !dead_gids.is_empty() {
+                self.prune_dead_gids(job_id, &dead_gids).await;
             }
         }
 
         Ok(())
     }
 
+    /// Drop dead gids from job, gid_index, and per-file aggregate.
+    async fn prune_dead_gids(&self, job_id: &str, dead: &[Gid]) {
+        let snap = {
+            let mut jobs = self.jobs.write().await;
+            let Some(job) = jobs.get_mut(job_id) else {
+                return;
+            };
+            job.gids.retain(|g| !dead.contains(g));
+            if let Some(s) = job.status.as_mut() {
+                for g in dead {
+                    s.per_file.remove(g);
+                }
+            }
+            job.metadata.updated_at = Utc::now();
+            job.clone()
+        };
+        {
+            let mut idx = self.gid_index.write().await;
+            for g in dead {
+                idx.remove(g);
+            }
+        }
+        self.emit_job_updated_throttled(&snap, true).await;
+        self.request_save_debounced().await;
+    }
+
+    /// Prune jobs against aria2's live gid set; respawn any that lost all gids.
+    pub async fn reconcile_after_reconnect(self: &Arc<Self>) {
+        use std::collections::HashSet;
+
+        let live: HashSet<String> = {
+            let aria_guard = self.aria.lock().await;
+            match aria_guard.list_all().await {
+                Ok(s) => s.into_iter().map(|st| st.gid).collect(),
+                Err(e) => {
+                    error!("reconcile: list_all failed: {:?}", e);
+                    return;
+                }
+            }
+        };
+
+        let mut respawn_targets: Vec<JobId> = Vec::new();
+        let mut prune_targets: Vec<(JobId, Vec<Gid>)> = Vec::new();
+        {
+            let jobs = self.jobs.read().await;
+            for (id, job) in jobs.iter() {
+                let dead: Vec<Gid> = job
+                    .gids
+                    .iter()
+                    .filter(|g| !live.contains(*g))
+                    .cloned()
+                    .collect();
+                if dead.is_empty() {
+                    continue;
+                }
+                let surviving = job.gids.len() - dead.len();
+                prune_targets.push((id.clone(), dead));
+                if surviving == 0
+                    && matches!(
+                        job.state,
+                        DownloadState::Active
+                            | DownloadState::Paused
+                            | DownloadState::Waiting
+                            | DownloadState::Error
+                    )
+                {
+                    respawn_targets.push(id.clone());
+                }
+            }
+        }
+
+        for (id, dead) in prune_targets {
+            self.prune_dead_gids(&id, &dead).await;
+        }
+
+        for id in respawn_targets {
+            info!("reconcile: respawning orphaned job {}", id);
+            if let Err(e) = self.resume(&id).await {
+                error!("reconcile: respawn failed for {}: {:?}", id, e);
+            }
+        }
+    }
+
     #[allow(unused)]
     pub async fn resume(self: &Arc<Self>, job_id: &str) -> Result<()> {
-        // ensure runnin because we might try to resume a download after restarting the app which will then not ask for UAC rights until install which is bad.
         if let Err(e) = fit_launcher_ui_automation::controller_manager::ControllerManager::global()
             .ensure_running()
         {
             error!("ControllerManager failed to start: {:?}", e);
         }
-        // We'll follow lock order AGAIN: read job metadata under jobs lock then release lock before RPC.
-        // Acquire a clone of the job to operate on, but keep a marker that we will update the real job later. This was decided to avoid any heavy locking.
+        // Read job metadata under the jobs lock, then release it before RPC.
         let job_opt = {
             let jobs = self.jobs.read().await;
             jobs.get(job_id).cloned()
@@ -425,6 +575,7 @@ impl DownloadManager {
                 self.emit_job_updated_throttled(&job, true).await;
             }
             self.request_save_debounced().await;
+            self.emit_aria2_status(Aria2ConnState::Connected, None);
             return Ok(());
         }
 
@@ -449,6 +600,7 @@ impl DownloadManager {
             );
             let mut new_gids = Vec::with_capacity(ddl.files.len());
 
+            let mut respawn_errors: Vec<String> = Vec::new();
             for f in ddl.files.iter() {
                 let aria_guard = self.aria.lock().await;
                 match aria_guard
@@ -461,19 +613,42 @@ impl DownloadManager {
                     .await
                 {
                     Ok(gid) => new_gids.push(gid),
-                    Err(e) => error!("Failed to respawn DDL gid for {}: {:?}", job.id, e),
+                    Err(e) => {
+                        error!("Failed to respawn DDL gid for {}: {:?}", job.id, e);
+                        respawn_errors.push(format!("{}: {}", f.filename, e));
+                    }
                 }
+            }
+
+            if new_gids.is_empty() && !respawn_errors.is_empty() {
+                self.emit_manager_error(
+                    "resume",
+                    format!("Could not resume DDL job: {}", respawn_errors.join("; ")),
+                    Some(job.id.clone()),
+                );
+            } else if !respawn_errors.is_empty() {
+                self.emit_manager_error(
+                    "resume_partial",
+                    format!("Some files failed to resume: {}", respawn_errors.join("; ")),
+                    Some(job.id.clone()),
+                );
             }
 
             if !new_gids.is_empty() {
                 let job_snapshot = {
                     let mut jobs = self.jobs.write().await;
                     if let Some(j) = jobs.get_mut(&job.id) {
-                        j.gids.extend(new_gids.iter().cloned());
-                        j.gids.sort();
-                        j.gids.dedup();
+                        // Replace stale gids; appending leaks dead entries into gid_index across restarts.
+                        let old_gids = std::mem::take(&mut j.gids);
+                        j.gids = new_gids.clone();
 
                         let mut gid_idx = self.gid_index.write().await;
+                        for g in old_gids.iter() {
+                            gid_idx.remove(g);
+                            if let Some(s) = j.status.as_mut() {
+                                s.per_file.remove(g);
+                            }
+                        }
                         for g in j.gids.iter() {
                             gid_idx.insert(g.clone(), j.id.clone());
                         }
@@ -490,6 +665,7 @@ impl DownloadManager {
                     self.emit_job_updated_throttled(&job, true).await;
                 }
                 self.request_save_debounced().await;
+                self.emit_aria2_status(Aria2ConnState::Connected, None);
             }
         }
         Ok(())
@@ -538,10 +714,18 @@ impl DownloadManager {
                 let job_snapshot = {
                     let mut jobs = self.jobs.write().await;
                     if let Some(j) = jobs.get_mut(&job.id) {
+                        // Drop stale gids before installing the new one to keep gid_index clean across restarts.
+                        let old_gids = std::mem::take(&mut j.gids);
                         j.gids = vec![new_gid.clone()];
                         j.state = DownloadState::Active;
                         j.metadata.updated_at = Utc::now();
                         let mut gid_idx = self.gid_index.write().await;
+                        for g in old_gids.iter() {
+                            gid_idx.remove(g);
+                            if let Some(s) = j.status.as_mut() {
+                                s.per_file.remove(g);
+                            }
+                        }
                         gid_idx.insert(new_gid, j.id.clone());
                         if let Some(t) = &j.torrent {
                             let mut ih = self.infohash_index.write().await;
@@ -557,9 +741,15 @@ impl DownloadManager {
                     self.emit_job_updated_throttled(&job, true).await;
                 }
                 self.request_save_debounced().await;
+                self.emit_aria2_status(Aria2ConnState::Connected, None);
             }
             Err(e) => {
                 error!("Failed to respawn torrent for job {}: {:?}", job.id, e);
+                self.emit_manager_error(
+                    "resume",
+                    format!("Could not resume torrent job: {}", e),
+                    Some(job.id.clone()),
+                );
                 return Err(e.into());
             }
         }
@@ -569,10 +759,11 @@ impl DownloadManager {
 
     pub async fn remove(&self, job_id: &str) -> Result<()> {
         // Remove job under lock and capture gids to remove outside
-        let gids_opt: Option<Vec<Gid>> = {
+        let remove_result: Option<(Vec<Gid>, bool)> = {
             let mut jobs = self.jobs.write().await;
             if let Some(job) = jobs.remove(job_id) {
                 let gids = job.gids.clone();
+                let empty_after_remove = jobs.is_empty();
 
                 let mut gid_idx = self.gid_index.write().await;
                 for gid in gids.iter() {
@@ -600,18 +791,22 @@ impl DownloadManager {
                 let _ = self
                     .tauri_handle
                     .emit("download::job_removed", job_id.to_string());
-                Some(gids)
+                Some((gids, empty_after_remove))
             } else {
                 None
             }
         };
 
-        if let Some(gids) = gids_opt {
+        if let Some((gids, empty_after_remove)) = remove_result {
             for gid in gids {
                 let aria_guard = self.aria.lock().await;
                 if let Err(e) = aria_guard.remove(&gid).await {
                     debug!("Failed to remove gid {} from aria2: {:?}", gid, e);
                 }
+            }
+            if empty_after_remove {
+                self.aria.lock().await.shutdown_if_owned().await;
+                self.emit_aria2_status(Aria2ConnState::Idle, None);
             }
             self.request_save_debounced().await;
         }
@@ -761,17 +956,16 @@ impl DownloadManager {
             if let Some((h, id)) = job_infohash_to_insert {
                 self.infohash_index.write().await.insert(h, id);
             }
-            self.gid_index.write().await.insert(gid.to_string(), job_id);
 
             if let Some(js) = job_snapshot {
                 self.emit_job_updated_throttled(&js, state_changed).await;
-                if matches!(js.state, DownloadState::Complete)
-                    || js
-                        .status
-                        .as_ref()
-                        .map(|s| s.completed_length >= s.total_length)
-                        .unwrap_or(false)
-                {
+                // Require total_length > 0 so 0/0 jobs don't fire spurious complete events.
+                let progress_complete = js
+                    .status
+                    .as_ref()
+                    .map(|s| s.total_length > 0 && s.completed_length >= s.total_length)
+                    .unwrap_or(false);
+                if matches!(js.state, DownloadState::Complete) || progress_complete {
                     let _ = self
                         .tauri_handle
                         .emit("download::job_completed", js.clone());

--- a/src-tauri/local-crates/fit-launcher-download-manager/src/types.rs
+++ b/src-tauri/local-crates/fit-launcher-download-manager/src/types.rs
@@ -34,6 +34,30 @@ pub enum ExclusionAction {
     Remove(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "kebab-case")]
+pub enum Aria2ConnState {
+    Idle,
+    Connected,
+    Reconnecting,
+    Disconnected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct Aria2StatusEvent {
+    pub state: Aria2ConnState,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagerErrorEvent {
+    pub kind: String,
+    pub message: String,
+    pub job_id: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Type)]
 #[serde(rename_all = "kebab-case")]
 #[derive(Default)]

--- a/src-tauri/local-crates/fit-launcher-scraping/src/discovery.rs
+++ b/src-tauri/local-crates/fit-launcher-scraping/src/discovery.rs
@@ -38,12 +38,12 @@ pub async fn try_high_res_img(src: &str) -> String {
     let hi = src.replace("240p", "1080p");
     let mid = hi.replace("jpg.1080p.", "");
 
+    // Fall back to the original src when neither high-res candidate exists
     tokio::select! {
         true = head_ok(&hi) => hi,
         true = head_ok(&mid) => mid,
+        else => src.into(),
     }
-
-    // src.into()
 }
 
 fn read_meta_ts(conn: &rusqlite::Connection) -> Option<DateTime<Utc>> {

--- a/src-tauri/local-crates/fit-launcher-torrent/Cargo.toml
+++ b/src-tauri/local-crates/fit-launcher-torrent/Cargo.toml
@@ -17,7 +17,6 @@ directories = { workspace = true }
 fit-launcher-ui-automation = { workspace = true }
 fit-launcher-scraping = { path = "../fit-launcher-scraping" }
 fitgirl-decrypt = { workspace = true }
-
 librqbit-core = { workspace = true }
 librqbit-buffers = { workspace = true }
 librqbit-dht = { version = "5.3.1" }
@@ -33,3 +32,6 @@ windows = { workspace = true, features = [
     "Win32_System_JobObjects",
     "Win32_Security",
 ] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/src-tauri/local-crates/fit-launcher-torrent/src/functions.rs
+++ b/src-tauri/local-crates/fit-launcher-torrent/src/functions.rs
@@ -11,10 +11,7 @@ use std::{
 };
 
 use tokio::{
-    sync::{
-        Mutex,
-        oneshot::{Receiver, Sender, channel},
-    },
+    sync::oneshot::{Receiver, Sender, channel},
     time::sleep,
 };
 
@@ -40,7 +37,8 @@ pub struct TorrentSession {
     pub config_filename: String,
     shared: Arc<RwLock<Option<StateShared>>>,
     init_lock: Arc<tokio::sync::Mutex<()>>,
-    aria2_child: Arc<tokio::sync::Mutex<Option<tokio::process::Child>>>,
+    // PID captured before Child moves into the shutdown task, for liveness checks.
+    aria2_pid: Arc<parking_lot::RwLock<Option<u32>>>,
 }
 
 unsafe impl Send for TorrentSession {}
@@ -139,6 +137,9 @@ fn build_aria2_args(
     // Session persistence --------------------------------------------------
     a.push("--save-session".into());
     a.push(session_path.display().to_string());
+    // 5s flush so a hard kill loses at most 5s of resume progress (default 60s).
+    a.push("--auto-save-interval=5".into());
+    a.push("--save-session-interval=5".into());
     a.push("--log".into());
     a.push(log_path.display().to_string());
     a.push("--log-level=warn".into());
@@ -162,7 +163,7 @@ pub async fn aria2_client_from_config(
     session_path: impl AsRef<OsStr>,
     log_path: impl AsRef<OsStr>,
     v2_path: impl AsRef<Path>,
-) -> anyhow::Result<aria2_ws::Client> {
+) -> anyhow::Result<(aria2_ws::Client, Option<u32>)> {
     let FitLauncherConfigAria2 {
         port,
         token,
@@ -181,7 +182,7 @@ pub async fn aria2_client_from_config(
         )
         .await
         {
-            Ok(client) => return Ok(client),
+            Ok(client) => return Ok((client, None)),
             Err(e) => {
                 warn!("Existing aria2 connection failed: {}", e);
             }
@@ -280,6 +281,8 @@ pub async fn aria2_client_from_config(
 
         info!("Successfully connected to newly created aria2c instance on port: {rpc_port}");
 
+        let pid = child.id();
+
         let (close_tx, close_rx) = channel::<()>();
         let (done_tx, done_rx) = channel::<()>();
 
@@ -297,7 +300,7 @@ pub async fn aria2_client_from_config(
         });
 
         *guard = Some((close_tx, done_rx, rpc_port));
-        Ok(client)
+        Ok((client, pid))
     } else {
         // when we don't start `aria2` ourself,
         // try to connect to the existing instance with configured port
@@ -307,7 +310,7 @@ pub async fn aria2_client_from_config(
         {
             Ok(client) => {
                 info!("Connected to existing aria2c instance on port: {port}");
-                Ok(client)
+                Ok((client, None))
             }
             Err(err) => {
                 error!("Failed to connect to existing aria2c instance on port {port}: {err}");
@@ -319,6 +322,29 @@ pub async fn aria2_client_from_config(
 
 fn is_port_available(port: u16) -> bool {
     TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+#[cfg(windows)]
+fn pid_alive(pid: u32) -> bool {
+    use windows::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let Ok(handle) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
+            return false;
+        };
+        let mut code: u32 = 0;
+        let alive = GetExitCodeProcess(handle, &mut code).is_ok() && code == STILL_ACTIVE.0 as u32;
+        let _ = CloseHandle(handle);
+        alive
+    }
+}
+
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    // kill(pid, 0) sends no signal but returns ESRCH if the process is gone.
+    unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 
 impl Default for TorrentSession {
@@ -349,7 +375,7 @@ impl TorrentSession {
 
         let final_config = load_or_migrate(legacy_path, v2_path);
 
-        let aria2_client =
+        let aria2_result =
             aria2_client_from_config(&final_config, aria2_session, aria2_log, v2_path)
                 .await
                 .inspect(|_| {
@@ -359,6 +385,12 @@ impl TorrentSession {
                     error!("Failed to connect to aria2: {:#}", e);
                 })
                 .ok();
+
+        let (aria2_client, aria2_pid) = match aria2_result {
+            Some((c, p)) => (Some(c), p),
+            None => (None, None),
+        };
+        self.set_aria2_pid(aria2_pid);
 
         let mut shared_guard = self.shared.write();
         if let Some(shared) = shared_guard.as_mut() {
@@ -399,8 +431,25 @@ impl TorrentSession {
             config_filename: v2_path.to_string_lossy().into(),
             shared,
             init_lock: Arc::new(tokio::sync::Mutex::new(())),
-            aria2_child: Arc::new(Mutex::new(None)),
+            aria2_pid: Arc::new(parking_lot::RwLock::new(None)),
         }
+    }
+
+    /// Spawned aria2c PID; None when connecting to an external instance.
+    pub fn aria2_pid(&self) -> Option<u32> {
+        *self.aria2_pid.read()
+    }
+
+    /// True when we don't own the daemon (can't verify) or its PID is still alive.
+    pub fn aria2_alive(&self) -> bool {
+        match self.aria2_pid() {
+            None => true,
+            Some(pid) => pid_alive(pid),
+        }
+    }
+
+    fn set_aria2_pid(&self, pid: Option<u32>) {
+        *self.aria2_pid.write() = pid;
     }
 
     pub async fn aria2_client(&self) -> anyhow::Result<aria2_ws::Client> {
@@ -454,24 +503,14 @@ impl TorrentSession {
     }
 
     pub async fn shutdown(&self) {
-        {
-            let handles = {
-                let mut guard = ARIA2_DAEMON.lock().await;
-                guard.take()
-            };
-            if let Some((close_tx, done_rx, _port)) = handles {
-                let _ = close_tx.send(());
-                let _ = done_rx.await;
-            }
+        let handles = {
+            let mut guard = ARIA2_DAEMON.lock().await;
+            guard.take()
+        };
+        if let Some((close_tx, done_rx, _port)) = handles {
+            let _ = close_tx.send(());
+            let _ = done_rx.await;
         }
-
-        if let Some(mut child) = self.aria2_child.lock().await.take() {
-            info!("Killing aria2c child process...");
-            if let Err(e) = child.kill().await {
-                error!("Failed to kill aria2c: {:?}", e);
-            } else {
-                let _ = child.wait().await;
-            }
-        }
+        *self.aria2_pid.write() = None;
     }
 }

--- a/src-tauri/local-crates/fit-launcher-torrent/src/hooks.rs
+++ b/src-tauri/local-crates/fit-launcher-torrent/src/hooks.rs
@@ -92,6 +92,11 @@ pub(crate) mod windows {
             unsafe { TerminateProcess(self.process, 1).ok() };
             Ok(())
         }
+
+        /// Mirrors `tokio::process::Child::id` for cross-platform PID capture.
+        pub fn id(&self) -> Option<u32> {
+            Some(self.pid)
+        }
     }
 
     /// Spawn a Child inside of a job object.

--- a/src-tauri/src/bootstrap/setup.rs
+++ b/src-tauri/src/bootstrap/setup.rs
@@ -5,6 +5,7 @@ use crate::utils::*;
 use fit_launcher_cache::CacheManager;
 use fit_launcher_download_manager::aria2::Aria2WsClient;
 use fit_launcher_download_manager::manager::DownloadManager;
+use fit_launcher_download_manager::types::Aria2ConnState;
 use fit_launcher_scraping::{
     discovery::refresh_discovery_games, rebuild_search_index, scraping::run_all_scrapers,
     sitemap::download_all_sitemaps,
@@ -138,21 +139,36 @@ pub async fn start_app() -> anyhow::Result<()> {
                                     let session_arc = Arc::clone(&session);
 
                                     info!("Download subsystem spawn: creating DownloadManager");
+                                    let aria_ws = Arc::new(Mutex::new(Aria2WsClient::new(
+                                        client.clone(),
+                                        session_arc,
+                                    )));
                                     let manager = DownloadManager::new(
-                                        Arc::new(Mutex::new(Aria2WsClient::new(client.clone(), session_arc))),
+                                        aria_ws.clone(),
                                         app.clone(),
                                         session.config().await.rpc,
                                         librqbit.clone(),
                                     );
 
+                                    // Register the manager BEFORE load_from_disk
+                                    app.manage(manager.clone());
+
                                     if let Err(e) = manager.load_from_disk().await {
                                         error!("Failed to load persisted jobs: {:?}", e);
+                                        manager.emit_manager_error(
+                                            "load_from_disk",
+                                            format!("{}", e),
+                                            None,
+                                        );
+                                    }
+                                    if manager.is_empty().await {
+                                        aria_ws.lock().await.shutdown_if_owned().await;
+                                        manager.emit_aria2_status(Aria2ConnState::Idle, None);
                                     }
 
-                                    info!("Download subsystem spawn: managing DownloadManager and starting dispatcher");
-                                    app.manage(manager.clone());
+                                    info!("Download subsystem spawn: starting dispatcher");
                                     fit_launcher_download_manager::dispatch::spawn_dispatcher(
-                                        manager, client,
+                                        manager, aria_ws,
                                     );
                                     info!("Download subsystem spawn: complete");
                                 }
@@ -277,8 +293,24 @@ pub async fn start_app() -> anyhow::Result<()> {
                 // This ensures ports are released for relaunch scenarios.
                 info!("RunEvent::Exit - shutting down subsystems");
 
+                // Flush pending debounced writes so a quick tray-quit doesn't drop the queue.
+                if let Some(manager) = app_handle.try_state::<Arc<DownloadManager>>() {
+                    let manager = manager.inner().clone();
+                    if let Err(e) = tauri::async_runtime::block_on(manager.save_now()) {
+                        error!("Final save_now failed during shutdown: {:?}", e);
+                    }
+                }
+
                 if let Some(librqbit) = app_handle.try_state::<LibrqbitSession>() {
                     librqbit.shutdown();
+                }
+
+                // Tear down idle install controller so a leaked pipe doesn't block the next launch.
+                #[cfg(windows)]
+                {
+                    let _ =
+                        fit_launcher_ui_automation::controller_manager::ControllerManager::global()
+                            .shutdown_if_idle();
                 }
 
                 info!("Subsystems shut down, process exiting");

--- a/src/Pop-Ups/Download-PopUp/LastStep.tsx
+++ b/src/Pop-Ups/Download-PopUp/LastStep.tsx
@@ -183,12 +183,10 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                 if (props.downloadType === "bittorrent") {
                     await initTorrent();
                 } else {
-                    await initDDL();
-                    // Also check if any debrid providers have this cached
-                    await checkDebridProviders();
+                    void checkDebridProviders();
                 }
             } catch (e) {
-                console.error("init error", e);
+                console.error("[download-modal] init error", e);
                 setError("Failed to initialize download");
             } finally {
                 setLoading(false);
@@ -213,20 +211,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
             } else {
                 console.error("getTorrentFileList failed", resultFiles.error);
                 setError("Failed to get torrent file list");
-            }
-        }
-
-        async function initDDL() {
-            try {
-                const links = await DM.getDatahosterLinks(props.downloadedGame.href, "");
-                if (!links || links.length === 0) {
-                    setError("No download links found for this game");
-                    return;
-                }
-                // don't auto-select hoster here — user picks one
-            } catch (e) {
-                console.error("initDDL error", e);
-                setError("Failed to initialize DDL links");
             }
         }
 
@@ -267,13 +251,12 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
             const path = settings.data.general.download_dir;
 
             if (folderExclusion()) {
-                console.log("performing folder exclusion...");
                 try {
                     const exclusionAction: ExclusionAction = { Add: path };
                     const res = await commands.folderExclusion(exclusionAction);
                     console.log("Folder successfully excluded:", res);
                 } catch (err) {
-                    console.error("Failed to exclude folder from Defender:", err);
+                    console.error("[download-modal] folder exclusion failed", err);
                     await showError(
                         "Could not exclude download folder from Windows Defender. The installation might be blocked.",
                         "Warning"
@@ -281,7 +264,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                 }
             }
 
-            // If debrid provider is selected, use the debrid download handler
             if (selectedDebridProvider()) {
                 return handleDebridDownload();
             }
@@ -289,7 +271,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
 
             try {
 
-                // Convert DownloadedGame to Game for DM API
                 const game = { ...props.downloadedGame, secondary_images: [] as string[] };
 
                 if (props.downloadType === "bittorrent") {
@@ -302,8 +283,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                     const selectedLinks = directLinks().filter(l => ddlSelectedUrls().has(l.url));
                     if (!selectedLinks.length) throw new Error("No files selected");
 
-                    console.log("adding DDL aria2 task...");
-
                     const result = await DM.addDdl(selectedLinks, path, game);
                     if (result.status === "error") {
                         throw new Error(result.error);
@@ -315,6 +294,7 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } catch (err: any) {
+                console.error("[download-modal] start download failed", err);
                 await showError(err, "Download Failed");
                 setError(err.message ?? "Failed");
             } finally {
@@ -344,7 +324,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                         setLoading(false);
                         return;
                     }
-                    // adapt to wrapper
                     const wrapped = extracted.map((e) => ({ ...e } as DirectLinkWrapper));
                     setDirectLinks(wrapped);
                     setDdlSelectedUrls(new Set(wrapped.map((w) => w.url)));
@@ -354,7 +333,7 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                     setDdlSelectedUrls(new Set(wrapped.map((w) => w.url)));
                 }
             } catch (e) {
-                console.error("loadHosterLinks error", e);
+                console.error("[download-modal] loadHosterLinks error", e);
                 setError(`Failed to load ${toTitleCaseExceptions(hoster)} links`);
             } finally {
                 setLoading(false);
@@ -365,54 +344,60 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
         async function checkDebridProviders() {
             setDebridProvidersLoading(true);
 
-            const magnet = props.downloadedGame.magnetlink;
-            const hash = magnet ? Debrid.extractHashFromMagnet(magnet) : null;
+            try {
+                const magnet = props.downloadedGame.magnetlink;
+                const hash = magnet ? Debrid.extractHashFromMagnet(magnet) : null;
 
-            const providerInfoList = await Debrid.listProviders();
-            setAllDebridProviders(providerInfoList);
+                const providerInfoList = await Debrid.listProviders();
+                setAllDebridProviders(providerInfoList);
 
-            const credInfo = await Debrid.listCredentials();
-            const configuredIds = new Set(credInfo.status === "ok" ? credInfo.data.configured_providers : []);
-            setConfiguredDebridProviders(configuredIds);
-            setDebridProvidersLoading(false);
+                const credInfo = await Debrid.listCredentials();
+                const configuredIds = new Set(credInfo.status === "ok" ? credInfo.data.configured_providers : []);
+                setConfiguredDebridProviders(configuredIds);
+                setDebridProvidersLoading(false);
 
-            if (hash && configuredIds.size > 0) {
-                const providersWithCreds = providerInfoList.filter(p => configuredIds.has(p.id));
-                await Promise.all(
-                    providersWithCreds
-                        .filter(p => p.supports_cache_check)
-                        .map(async (p) => {
-                            try {
-                                const result = await Debrid.checkCache(p.id, hash);
-                                if (result.status === "ok") {
-                                    setDebridCacheStatus(prev => {
-                                        const next = new Map(prev);
-                                        next.set(p.id, result.data.is_cached);
-                                        return next;
-                                    });
-                                } else {
-                                    if (result.error === "InvalidApiKey") {
-                                        setInvalidApiProviders(prev => {
-                                            const next = new Set(prev);
-                                            next.add(p.id);
+                if (hash && configuredIds.size > 0) {
+                    const providersWithCreds = providerInfoList.filter(p => configuredIds.has(p.id));
+                    await Promise.all(
+                        providersWithCreds
+                            .filter(p => p.supports_cache_check)
+                            .map(async (p) => {
+                                try {
+                                    const result = await Debrid.checkCache(p.id, hash);
+                                    if (result.status === "ok") {
+                                        setDebridCacheStatus(prev => {
+                                            const next = new Map(prev);
+                                            next.set(p.id, result.data.is_cached);
+                                            return next;
+                                        });
+                                    } else {
+                                        if (result.error === "InvalidApiKey") {
+                                            setInvalidApiProviders(prev => {
+                                                const next = new Set(prev);
+                                                next.add(p.id);
+                                                return next;
+                                            });
+                                        }
+                                        setDebridCacheStatus(prev => {
+                                            const next = new Map(prev);
+                                            next.set(p.id, false);
                                             return next;
                                         });
                                     }
+                                } catch {
                                     setDebridCacheStatus(prev => {
                                         const next = new Map(prev);
                                         next.set(p.id, false);
                                         return next;
                                     });
                                 }
-                            } catch {
-                                setDebridCacheStatus(prev => {
-                                    const next = new Map(prev);
-                                    next.set(p.id, false);
-                                    return next;
-                                });
-                            }
-                        })
-                );
+                            })
+                    );
+                }
+            } catch (e) {
+                console.error("[download-modal] debrid providers failed", e);
+            } finally {
+                setDebridProvidersLoading(false);
             }
         }
 
@@ -430,7 +415,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
             try {
                 const magnet = props.downloadedGame.magnetlink;
 
-                // Add torrent to provider (returns torrent ID)
                 const addResult = await Debrid.addTorrent(provider, magnet);
                 if (addResult.status !== "ok") {
                     throw new Error(`Failed to add torrent: ${addResult.error}`);
@@ -439,14 +423,11 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                 const torrentId = addResult.data;
                 setDebridTorrentId(torrentId);
 
-                // For providers that don't support cache check, we poll for ready status
                 const providerInfo = allDebridProviders().find(p => p.id === provider);
                 if (providerInfo && !providerInfo.supports_cache_check) {
-                    // Poll for up to 3 seconds to see if torrent becomes ready
                     const readyResult = await Debrid.waitForTorrentReady(provider, torrentId, 3000, 500);
 
                     if (!readyResult.ready && readyResult.status) {
-                        // Torrent is still caching - show caching UI
                         setDebridCachingStatus({
                             isCaching: true,
                             progress: readyResult.status.progress,
@@ -463,7 +444,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                     }
                 }
 
-                // Get torrent info with file list
                 const infoResult = await Debrid.getTorrentInfo(provider, torrentId);
                 if (infoResult.status !== "ok") {
                     throw new Error(`Failed to get torrent info: ${infoResult.error}`);
@@ -472,12 +452,11 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                 const files = infoResult.data.files;
                 setDebridFiles(files);
 
-                // Auto-select all files
                 setSelectedDebridFiles(new Set(files.map(f => f.id)));
 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } catch (e: any) {
-                console.error("loadDebridProvider error", e);
+                console.error("[download-modal] loadDebridProvider error", e);
                 setError(e.message ?? `Failed to load from ${provider}`);
                 setSelectedDebridProvider(null);
             } finally {
@@ -499,7 +478,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
 
             const status = result.data;
             if (status.is_ready) {
-                // Torrent is now ready! Load the files
                 setDebridCachingStatus(null);
                 setLoading(true);
 
@@ -514,12 +492,12 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                     setSelectedDebridFiles(new Set(files.map(f => f.id)));
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 } catch (e: any) {
+                    console.error("[download-modal] debrid ready load failed", e);
                     setError(e.message ?? "Failed to load files");
                 } finally {
                     setLoading(false);
                 }
             } else {
-                // Still caching - update progress
                 setDebridCachingStatus({
                     isCaching: true,
                     progress: status.progress,
@@ -539,7 +517,7 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
             try {
                 await Debrid.deleteTorrent(provider, torrentId);
             } catch (e) {
-                console.error("Failed to delete torrent", e);
+                console.error("[download-modal] failed to delete torrent", e);
             }
 
             setDebridCachingStatus(null);
@@ -586,7 +564,6 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
 
                 const path = settings.data.general.download_dir;
 
-                // Filter selected files
                 const selectedIds = selectedDebridFiles();
                 const filesToDownload = debridFiles().filter(f => selectedIds.has(f.id));
 
@@ -594,16 +571,13 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
                     throw new Error("No files selected");
                 }
 
-                // Get download links for selected files
                 const linksResult = await Debrid.getDownloadLinks(provider, torrentId, filesToDownload);
                 if (linksResult.status !== "ok") {
                     throw new Error(`Failed to get download links: ${linksResult.error}`);
                 }
 
-                // Convert to DirectLinkWrapper for aria2
                 const wrappedLinks: DirectLinkWrapper[] = Debrid.toDirectLinks(linksResult.data);
 
-                // Use existing DDL mechanism - convert DownloadedGame to Game
                 const gameForDm = { ...props.downloadedGame, secondary_images: [] as string[] };
                 await DM.addDdl(wrappedLinks, path, gameForDm);
 
@@ -612,6 +586,7 @@ export default function createLastStepDownloadPopup(props: DownloadPopupProps) {
 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } catch (err: any) {
+                console.error("[download-modal] debrid download failed", err);
                 await showError(err, "Error");
                 setError(err.message ?? "Failed");
             } finally {

--- a/src/api/manager/api.ts
+++ b/src/api/manager/api.ts
@@ -15,6 +15,23 @@ import {
 type JobCallback = (job: Job) => void;
 type RemovedCallback = (id: string) => void;
 
+export type Aria2ConnState =
+  | "idle"
+  | "connected"
+  | "reconnecting"
+  | "disconnected";
+export interface Aria2StatusEvent {
+  state: Aria2ConnState;
+  message?: string | null;
+}
+export interface ManagerErrorEvent {
+  kind: string;
+  message: string;
+  jobId?: string | null;
+}
+type StatusCallback = (s: Aria2StatusEvent) => void;
+type ErrorCallback = (e: ManagerErrorEvent) => void;
+
 export class GlobalDownloadManager {
   private jobs = new Map<string, Job>();
 
@@ -34,6 +51,16 @@ export class GlobalDownloadManager {
   private unlistenUpdated: UnlistenFn | null = null;
   private unlistenRemoved: UnlistenFn | null = null;
   private unlistenCompleted: UnlistenFn | null = null;
+  private unlistenManagerReady: UnlistenFn | null = null;
+  private unlistenAria2Status: UnlistenFn | null = null;
+  private unlistenManagerError: UnlistenFn | null = null;
+
+  private readyCbs: Set<() => void> = new Set();
+  private isReady = false;
+
+  private statusCbs: Set<StatusCallback> = new Set();
+  private errorCbs: Set<ErrorCallback> = new Set();
+  private currentStatus: Aria2StatusEvent = { state: "reconnecting" };
 
   private flushUpdates() {
     this.flushScheduled = false;
@@ -70,6 +97,7 @@ export class GlobalDownloadManager {
   }
 
   async setup() {
+    // Listeners must be attached BEFORE the initial dmAllJobs call
     if (!this.unlistenUpdated) {
       this.unlistenUpdated = await listen("download::job_updated", (e) => {
         const job = e.payload as Job | null;
@@ -126,26 +154,144 @@ export class GlobalDownloadManager {
       });
     }
 
+    if (!this.unlistenAria2Status) {
+      this.unlistenAria2Status = await listen(
+        "download::aria2_status",
+        (e) => {
+          const s = e.payload as Aria2StatusEvent;
+          if (!s?.state) return;
+          this.notifyStatus(s);
+        }
+      );
+    }
+
+    if (!this.unlistenManagerError) {
+      this.unlistenManagerError = await listen(
+        "download::manager_error",
+        (e) => {
+          const err = e.payload as ManagerErrorEvent;
+          if (!err?.message) return;
+          this.errorCbs.forEach((cb) => {
+            try {
+              cb(err);
+            } catch (cbErr) {
+              console.error("Error in manager error callback:", cbErr);
+            }
+          });
+        }
+      );
+    }
+
+    // Backend spawns the manager async, so the initial fetch races; manager_ready triggers a refetch.
+    if (!this.unlistenManagerReady) {
+      this.unlistenManagerReady = await listen(
+        "download::manager_ready",
+        () => {
+          this.isReady = true;
+          this.refetchAll().catch((err) =>
+            console.error("Refetch after manager_ready failed:", err)
+          );
+          this.refetchAria2Status().catch((err) =>
+            console.error("Aria2 status refetch after manager_ready failed:", err)
+          );
+          this.readyCbs.forEach((cb) => {
+            try {
+              cb();
+            } catch (err) {
+              console.error("Error in manager ready callback:", err);
+            }
+          });
+        }
+      );
+    }
+
+    await this.refetchAria2Status();
+    await this.refetchAll();
+  }
+
+  private notifyStatus(s: Aria2StatusEvent) {
+    this.currentStatus = s;
+    this.statusCbs.forEach((cb) => {
+      try {
+        cb(s);
+      } catch (err) {
+        console.error("Error in aria2 status callback:", err);
+      }
+    });
+  }
+
+  private async refetchAria2Status() {
+    try {
+      const res = await commands.dmAria2Status();
+      if (res.status === "ok") {
+        this.notifyStatus(res.data);
+      }
+    } catch (err) {
+      console.warn("dmAria2Status failed:", err);
+    }
+  }
+
+  private async refetchAll() {
     try {
       const resAll = await commands.dmAllJobs();
-      let all: Job[] = [];
-      if (resAll.status === "ok") {
-        all = resAll.data;
+      if (resAll.status !== "ok") {
+        console.warn("dmAllJobs not ready:", resAll.error);
+        return;
       }
-      if (Array.isArray(all)) {
-        for (const j of all) {
-          if (j && j.id) {
-            this.jobs.set(j.id, j);
-            if (j.state === "complete") {
-              this.completedJobIds.add(j.id);
-            }
+      const all = resAll.data;
+      if (!Array.isArray(all)) return;
+
+      for (const j of all) {
+        if (j && j.id) {
+          this.jobs.set(j.id, j);
+          if (j.state === "complete") {
+            this.completedJobIds.add(j.id);
           }
+          // Notify subscribers on cold restart; stale gids may never trigger a live update.
+          this.updatedCbs.forEach((cb) => {
+            try {
+              cb(j);
+            } catch (err) {
+              console.error("Error in job updated callback:", err);
+            }
+          });
         }
-        this.cleanupCompletedJobs();
       }
+      this.cleanupCompletedJobs();
     } catch (err) {
       console.warn("dmAllJobs failed:", err);
     }
+  }
+
+  onReady(cb: () => void) {
+    this.readyCbs.add(cb);
+    if (this.isReady) {
+      try {
+        cb();
+      } catch (err) {
+        console.error("Error in manager ready callback:", err);
+      }
+    }
+    return () => this.readyCbs.delete(cb);
+  }
+
+  getAria2Status(): Aria2StatusEvent {
+    return this.currentStatus;
+  }
+
+  onAria2Status(cb: StatusCallback) {
+    this.statusCbs.add(cb);
+    try {
+      cb(this.currentStatus);
+    } catch (err) {
+      console.error("Error in aria2 status callback:", err);
+    }
+    return () => this.statusCbs.delete(cb);
+  }
+
+  onError(cb: ErrorCallback) {
+    this.errorCbs.add(cb);
+    return () => this.errorCbs.delete(cb);
   }
 
   // getters
@@ -250,6 +396,7 @@ export class GlobalDownloadManager {
   async resume(jobId: string): Promise<Result<void, string>> {
     try {
       await commands.dmResume(jobId);
+      await this.refetchAria2Status();
       return { data: undefined, status: "ok" };
     } catch (e) {
       return {
@@ -362,10 +509,27 @@ export class GlobalDownloadManager {
       this.unlistenCompleted();
       this.unlistenCompleted = null;
     }
+    if (this.unlistenManagerReady) {
+      this.unlistenManagerReady();
+      this.unlistenManagerReady = null;
+    }
+    if (this.unlistenAria2Status) {
+      this.unlistenAria2Status();
+      this.unlistenAria2Status = null;
+    }
+    if (this.unlistenManagerError) {
+      this.unlistenManagerError();
+      this.unlistenManagerError = null;
+    }
 
     this.updatedCbs.clear();
     this.removedCbs.clear();
     this.completedCbs.clear();
+    this.readyCbs.clear();
+    this.statusCbs.clear();
+    this.errorCbs.clear();
+    this.isReady = false;
+    this.currentStatus = { state: "reconnecting" };
 
     this.jobs.clear();
     this.pendingUpdates.clear();

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -275,6 +275,14 @@ async dmAllJobs() : Promise<Result<Job[], string>> {
     else return { error: e  as any, status: "error" };
 }
 },
+async dmAria2Status() : Promise<Result<Aria2StatusEvent, string>> {
+    try {
+    return { data: await TAURI_INVOKE("dm_aria2_status"), status: "ok" };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { error: e  as any, status: "error" };
+}
+},
 async dmCleanJob(jobId: string, installationId: string) : Promise<Result<null, InstallationError>> {
     try {
     return { data: await TAURI_INVOKE("dm_clean_job", { installationId, jobId }), status: "ok" };
@@ -709,7 +717,9 @@ async updateDownloadedGameExecutableInfo(gameTitle: string, executableInfo: Exec
 
 export type AggregatedStatus = { total_length: number; completed_length: number; download_speed: number; upload_speed: number; per_file: Partial<{ [key in string]: FileStatus }>; state: DownloadState; progress_percentage: number }
 export type AnswerComment = { id: number; text_template: string | null; data_create: string | null; user: User | null; raiting: Rating | null; attaches?: Attach[] | null; attaches_icons?: number[] | null; attaches_text: string | null; sort: number | null; edited: boolean | null; fixed: boolean | null; comment_type: number | null; answer_comment_root_id: number | null }
+export type Aria2ConnState = "idle" | "connected" | "reconnecting" | "disconnected"
 export type Aria2Error = "NotConfigured" | { InitializationFailed: string } | { RPCError: string } | { Timeout: string } | "StaleConnection"
+export type Aria2StatusEvent = { state: Aria2ConnState; message: string | null }
 export type Attach = { type: string; data?: AttachType[] }
 export type AttachType = { src: string | null; src_o: string | null; width: number | null; video: string | null; webp: string | null; height: number | null; title: string | null; type: string | null; description: string | null }
 /**

--- a/src/components/UI/Dropdown/Dropdown.tsx
+++ b/src/components/UI/Dropdown/Dropdown.tsx
@@ -6,7 +6,6 @@ import { DropdownProps } from "../../../types/components/types";
 export default function Dropdown<T extends string | number>(props: DropdownProps<T>) {
     const [isOpen, setIsOpen] = createSignal(false);
     const [isAnimating, setIsAnimating] = createSignal(false);
-    const [setHoveredItem] = createSignal<T | null>(null);
 
     const handleSelection = async (item: T) => {
         setIsAnimating(true);
@@ -53,11 +52,7 @@ export default function Dropdown<T extends string | number>(props: DropdownProps
                             const isActive = item === props.activeItem;
 
                             return (
-                                <li
-                                    class="relative group flex justify-between min-w-full"
-                                    onMouseEnter={() => setHoveredItem(() => item)}
-                                    onMouseLeave={() => setHoveredItem(null)}
-                                >
+                                <li class="relative group flex justify-between min-w-full">
                                     <button
                                         onClick={() => handleSelection(item)}
                                         class={`

--- a/src/pages/Downloads-01/Downloads-Page.tsx
+++ b/src/pages/Downloads-01/Downloads-Page.tsx
@@ -1,5 +1,5 @@
-import { Component, createMemo, createSignal } from "solid-js";
-import { CloudDownload, Funnel, Magnet, DownloadCloud, Zap, Trash2, ArrowDown, ArrowUp, Activity } from "lucide-solid";
+import { Component, createMemo, createSignal, For, Show } from "solid-js";
+import { CloudDownload, Funnel, Magnet, DownloadCloud, Zap, Trash2, ArrowDown, ArrowUp, Activity, AlertTriangle, WifiOff, RefreshCw, X } from "lucide-solid";
 import Button from "../../components/UI/Button/Button";
 import { useNavigate } from "@solidjs/router";
 import InstallQueueStatus from "../../components/InstallQueue/QueueStatus";
@@ -9,6 +9,7 @@ import { DM } from "../../api/manager/api";
 import { AggregatedStatus, DownloadSource } from "../../bindings";
 import { DownloadsStore } from "../../stores/download";
 import { GlobalStatsStore } from "../../stores/globalStats";
+import { ManagerStatusStore } from "../../stores/managerStatus";
 
 type FilterType = DownloadSource | "All" | "Active";
 
@@ -64,8 +65,57 @@ const DownloadPage: Component = () => {
 
 
 
+    const { status: aria2Status, recentErrors, dismissError } = ManagerStatusStore;
+
     return (
         <div class="min-h-screen bg-gradient-to-br from-background to-background-950 p-4 w-full">
+            <div class="max-w-[1800px] mx-auto">
+                <Show when={aria2Status().state === "reconnecting" || aria2Status().state === "disconnected"}>
+                    <div
+                        class={`flex items-center gap-3 px-4 py-3 rounded-xl border mb-4 ${aria2Status().state === "disconnected"
+                            ? "bg-red-500/10 border-red-400/40 text-red-300"
+                            : "bg-amber-500/10 border-amber-400/40 text-amber-300"
+                            }`}
+                    >
+                        {aria2Status().state === "disconnected" ? (
+                            <WifiOff class="w-5 h-5 shrink-0" />
+                        ) : (
+                            <RefreshCw class="w-5 h-5 shrink-0 animate-spin" />
+                        )}
+                        <div class="flex flex-col">
+                            <span class="font-bold">
+                                {aria2Status().state === "disconnected"
+                                    ? "Download engine disconnected"
+                                    : "Reconnecting to download engine..."}
+                            </span>
+                            <Show when={aria2Status().message}>
+                                <span class="text-xs opacity-80">{aria2Status().message}</span>
+                            </Show>
+                        </div>
+                    </div>
+                </Show>
+
+                <For each={recentErrors()}>
+                    {(err) => (
+                        <div class="flex items-start gap-3 px-4 py-3 rounded-xl border border-red-400/40 bg-red-500/10 text-red-200 mb-2">
+                            <AlertTriangle class="w-5 h-5 shrink-0 mt-0.5" />
+                            <div class="flex flex-col flex-1 min-w-0">
+                                <span class="font-bold text-sm uppercase tracking-wider opacity-80">
+                                    {err.kind.replace(/_/g, " ")}
+                                </span>
+                                <span class="text-sm break-words">{err.message}</span>
+                            </div>
+                            <button
+                                onClick={() => dismissError(err)}
+                                class="p-1 rounded hover:bg-red-500/20 transition-colors shrink-0"
+                                aria-label="Dismiss"
+                            >
+                                <X class="w-4 h-4" />
+                            </button>
+                        </div>
+                    )}
+                </For>
+            </div>
             <div class="max-w-[1800px] mx-auto mb-8">
                 <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
                     <h1 class="text-3xl font-bold flex items-center gap-3">

--- a/src/stores/managerStatus.ts
+++ b/src/stores/managerStatus.ts
@@ -1,0 +1,31 @@
+import { createRoot, createSignal } from "solid-js";
+import { DM, Aria2StatusEvent, ManagerErrorEvent } from "../api/manager/api";
+
+const RECENT_ERROR_MAX = 5;
+const ERROR_TTL_MS = 10_000;
+
+export const createManagerStatusStore = () => {
+  const [status, setStatus] = createSignal<Aria2StatusEvent>(
+    DM.getAria2Status()
+  );
+  const [recentErrors, setRecentErrors] = createSignal<ManagerErrorEvent[]>([]);
+
+  DM.onAria2Status((s) => setStatus(s));
+
+  DM.onError((err) => {
+    setRecentErrors((prev) => [...prev.slice(-(RECENT_ERROR_MAX - 1)), err]);
+    setTimeout(() => {
+      setRecentErrors((prev) => prev.filter((e) => e !== err));
+    }, ERROR_TTL_MS);
+  });
+
+  return {
+    status,
+    recentErrors,
+    dismissError: (target: ManagerErrorEvent) => {
+      setRecentErrors((prev) => prev.filter((e) => e !== target));
+    },
+  };
+};
+
+export const ManagerStatusStore = createRoot(createManagerStatusStore);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node",
     "strict": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",


### PR DESCRIPTION
Fixes download-manager state drift around restart, aria2 reconnects, stale gids, pause handling, and user-visible download engine errors and improves DDL speed by switching to reqwest and run debrid checks in background which slow down DDL fetch

Refs #230
Refs #237
Closes #248
Closes #262
Closes #263
Closes #264
Closes #270
Closes #273

## Fixed

| Issue | Fix |
|---|---|
| #248 | Persisted jobs are restored after backend startup and pushed to the UI via `download::manager_ready` / `download::job_updated`. |
| #262 / #263 | Dispatcher now reconnects stale aria2 RPC clients, respawns owned `aria2c` when its PID dies, and reconciles stale gids after reconnect. |
| #264 / #273 | FuckingFast extraction accepts the new url `dl.fuckingfast.co`, uses a dedicated browser-like client, and avoids the custom DNS timeout path for FF pages. |
| #270 | Pause preserves last status, handles stale/non-pausable gids quietly, and no longer emits false complete events for 0/0 jobs. |
| #230 | Partially addressed by deterministic job IDs, more frequent aria2 session saves, reconnect handling, and stale-gid cleanup. No full per-task retry loop yet. |
| #237 | Partially addressed by shutting down idle controller state on app exit. |

## Backend

- Register `DownloadManager` before `load_from_disk`.
- Emit restored jobs and `download::manager_ready` after disk load.
- Route polling through `Aria2WsClient` instead of a raw aria2 client.
- Reconnect after repeated RPC failures and fast-path respawn when the owned aria2 PID is gone.
- Add `download::aria2_status` states: `idle`, `connected`, `reconnecting`, `disconnected`.
- Add `download::manager_error` for actionable pause/resume/load failures.
- Preserve paused-job status instead of clearing progress.
- Replace stale gids on resume instead of appending new gids.
- Prune dead gids from jobs, `gid_index`, and per-file status after reconnect.
- Require `total_length > 0` before progress-based complete events.
- Shut down owned aria2 when the queue becomes empty.
- Flush pending manager saves on app exit.
- Use a dedicated FuckingFast reqwest client with Chrome UA and default resolver behavior.

## Frontend

- Listen for `download::aria2_status`, `download::manager_error`, and `download::manager_ready`.
- Add manager status store with capped, auto-expiring error toasts.
- Show reconnect/disconnected banners only for real non-idle engine states.
- Fetch DDL hoster links only after the user picks a hoster.
- Run debrid provider checks in the background so they do not block FuckingFast selection.
- Remove dead `setHoveredItem` state in `Dropdown.tsx`.

## Tests

- [x] DDL job survives app restart and resumes.
- [x] Torrent job survives app restart and resumes.
- [x] Killing `aria2c.exe` during a download shows reconnecting, respawns aria2, clears the banner, and progress resumes.
- [x] Permanent reconnect failure shows disconnected state.
- [x] Pause RPC failures produce error toasts only for real failures.
- [x] Tray quit/relaunch does not leave a stale controller process.
- [x] Empty queue cold boot shows no reconnect/disconnected banner and leaves no owned `aria2c` running.
- [x] DDL modal can start FuckingFast loading while debrid checks continue in the background.
