### PR TITLE
Add Simplified Chinese i18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@tauri-apps/plugin-store": "2.4.1",
         "@tauri-apps/plugin-updater": "^2.3.0",
         "dompurify": "^3.3.2",
+        "i18next": "^26.3.1",
         "lucide-solid": "^0.561.0",
         "marked": "^17.0.1",
         "semver": "^7.7.3",
@@ -82,6 +83,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2792,6 +2794,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2855,6 +2858,7 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3072,6 +3076,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3334,6 +3339,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3668,6 +3674,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -3944,6 +3951,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4376,6 +4384,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.3.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.1.tgz",
+      "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ignore": {
@@ -5492,6 +5528,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -5656,6 +5693,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.4.2.tgz",
       "integrity": "sha512-N3HEHRCZYn3cQbsC4B5ldj9j+tHdf4JZoYPlcI4rRYu0Xy4qN8MQf1Z08EibzB0WpgRG5BGK08FTrmM66eSzKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5743,6 +5781,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.6.tgz",
       "integrity": "sha512-PoasAJvLk60hRtOTe9ulvALOdLjjqxuxcGZRolBQqxOnXrBXHGzqMT4ijNhGsDAYdOgEa8ZYaAE94PSldrFSkA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "^1.1.0",
@@ -5948,6 +5987,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5998,8 +6038,9 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6105,6 +6146,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6240,6 +6282,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tauri-apps/plugin-store": "2.4.1",
     "@tauri-apps/plugin-updater": "^2.3.0",
     "dompurify": "^3.3.2",
+    "i18next": "^26.3.1",
     "lucide-solid": "^0.561.0",
     "marked": "^17.0.1",
     "semver": "^7.7.3",

--- a/src/components/Topbar-01/Topbar-Components-01/Searchbar-01/Searchbar.tsx
+++ b/src/components/Topbar-01/Topbar-Components-01/Searchbar-01/Searchbar.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@solidjs/router";
 import { Search, X, Sparkles, Loader2 } from "lucide-solid";
 import { commands } from "../../../../bindings";
 import { listen } from "@tauri-apps/api/event";
+import { t } from "../../../../i18n";
 
 interface SearchbarProps {
   isTopBar?: boolean;
@@ -47,7 +48,7 @@ export default function Searchbar(props: SearchbarProps) {
     });
 
     errorUnlisten = await listen<string>("search-index-error", (event) => {
-      setIndexError(event.payload || "Search index error");
+      setIndexError(event.payload || t("search.indexError"));
     });
   });
 
@@ -95,7 +96,7 @@ export default function Searchbar(props: SearchbarProps) {
         setSearchResults([]);
         // Only show error if it's not a "database not found" (index still building)
         if (!String(result.error).includes("not found")) {
-          setIndexError("Search failed");
+          setIndexError(t("search.failed"));
         }
       }
     } catch (err) {
@@ -176,7 +177,7 @@ export default function Searchbar(props: SearchbarProps) {
 
         <input
           type="text"
-          placeholder="Search Game..."
+          placeholder={t("search.placeholder")}
           value={searchTerm()}
           onInput={handleInputChange}
           onFocus={() => setIsFocused(true)}

--- a/src/components/Topbar-01/Topbar.tsx
+++ b/src/components/Topbar-01/Topbar.tsx
@@ -8,6 +8,7 @@ import { sendNotification, isPermissionGranted, requestPermission } from "@tauri
 import createBasicChoicePopup from "../../Pop-Ups/Basic-Choice-PopUp/Basic-Choice-PopUp";
 import { GlobalSettingsApi } from "../../api/settings/api";
 import { commands } from "../../bindings";
+import { t } from "../../i18n";
 import { routeHistory } from "../../stores/routeStore";
 
 export default function Topbar() {
@@ -33,8 +34,8 @@ export default function Topbar() {
       }
       if (permissionGranted) {
         sendNotification({
-          title: "FitLauncher is running in the tray",
-          body: "The app was minimized to the system tray. You can change this behavior in Settings."
+          title: t("topbar.trayTitle"),
+          body: t("topbar.trayBody")
         });
       }
       return;
@@ -46,10 +47,10 @@ export default function Topbar() {
     if (controllerRunning) {
       // Warn user that controller will be killed
       createBasicChoicePopup({
-        infoTitle: "Installation In Progress",
-        infoMessage: "An installation is currently running. Closing will stop the installation.\n\nAre you sure you want to exit?",
-        confirmLabel: "Exit Anyway",
-        cancelLabel: "Cancel",
+        infoTitle: t("topbar.installationInProgress"),
+        infoMessage: t("topbar.installationExitWarning"),
+        confirmLabel: t("topbar.exitAnyway"),
+        cancelLabel: t("common.cancel"),
         action: async () => {
           await commands.quitApp();
         },
@@ -138,7 +139,7 @@ export default function Topbar() {
       {/* Logo */}
       <img
         src='/Square310x310Logo.png'
-        alt='fitgirl repack logo'
+        alt={t("topbar.logoAlt")}
         class="w-8 h-8 rounded-md object-cover"
         style="-webkit-app-region: no-drag;"
       />
@@ -157,7 +158,7 @@ export default function Topbar() {
           end
         >
           <Home size={18} />
-          <span class="font-medium">GameHub</span>
+          <span class="font-medium">{t("topbar.gameHub")}</span>
         </A>
 
         <A
@@ -166,7 +167,7 @@ export default function Topbar() {
             }`}
         >
           <Compass size={18} />
-          <span class="font-medium">Discovery</span>
+          <span class="font-medium">{t("topbar.discovery")}</span>
         </A>
 
         <A
@@ -175,7 +176,7 @@ export default function Topbar() {
             }`}
         >
           <Library size={18} />
-          <span class="font-medium">Library</span>
+          <span class="font-medium">{t("topbar.library")}</span>
         </A>
 
         <A
@@ -184,7 +185,7 @@ export default function Topbar() {
             }`}
         >
           <Download size={18} />
-          <span class="font-medium">Downloads</span>
+          <span class="font-medium">{t("topbar.downloads")}</span>
         </A>
 
         <A
@@ -193,7 +194,7 @@ export default function Topbar() {
             }`}
         >
           <Settings size={18} />
-          <span class="font-medium">Settings</span>
+          <span class="font-medium">{t("topbar.settings")}</span>
         </A>
       </div>
 
@@ -205,7 +206,7 @@ export default function Topbar() {
           <button
             id="titlebar-minimize"
             class="p-1.5 rounded-full text-muted hover:bg-secondary-20/30 hover:text-accent transition-colors"
-            title="Minimize"
+            title={t("topbar.minimize")}
           >
             <Minus size={16} />
           </button>
@@ -216,10 +217,10 @@ export default function Topbar() {
             onClick={handleMaximize}
             title={
               isFullscreen()
-                ? "Exit Fullscreen"
+                ? t("topbar.exitFullscreen")
                 : isMaximized()
-                  ? "Restore Down"
-                  : "Maximize"
+                  ? t("topbar.restoreDown")
+                  : t("topbar.maximize")
             }
           >
             <Show when={isFullscreen() || isMaximized()} fallback={<Maximize2 size={16} />}>
@@ -230,7 +231,7 @@ export default function Topbar() {
           <button
             id="titlebar-close"
             class="p-1.5 rounded-full text-muted hover:bg-red-500/20 hover:text-red-500 transition-colors"
-            title="Close"
+            title={t("topbar.close")}
           >
             <X size={16} />
           </button>

--- a/src/components/UI/Dropdown/Dropdown.tsx
+++ b/src/components/UI/Dropdown/Dropdown.tsx
@@ -1,12 +1,13 @@
 import { ChevronDown, X } from "lucide-solid";
 import { createSignal, Show } from "solid-js";
+import { t } from "../../../i18n";
 import { DropdownProps } from "../../../types/components/types";
 
 
 export default function Dropdown<T extends string | number>(props: DropdownProps<T>) {
     const [isOpen, setIsOpen] = createSignal(false);
     const [isAnimating, setIsAnimating] = createSignal(false);
-    const [setHoveredItem] = createSignal<T | null>(null);
+    const [, setHoveredItem] = createSignal<T | null>(null);
 
     const handleSelection = async (item: T) => {
         setIsAnimating(true);
@@ -81,7 +82,7 @@ export default function Dropdown<T extends string | number>(props: DropdownProps
                                                     await props.onRemove?.(item);
                                                 }}
                                                 class="p-2 h-full border-l-1 border-secondary-20/50 transition-all duration-200 text-muted hover:text-primary hover:bg-accent/30"
-                                                title="Remove"
+                                                title={t("common.remove")}
                                             >
                                                 <X size={14} class="transition-transform hover:scale-110" />
                                             </button>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,57 @@
+import i18next, { type TOptions } from "i18next";
+import { createSignal } from "solid-js";
+import en from "./locales/en.json";
+import zhCN from "./locales/zh-CN.json";
+
+export const LANGUAGE_STORAGE_KEY = "language";
+export const SUPPORTED_LANGUAGES = {
+  en: "English",
+  "zh-CN": "简体中文",
+} as const;
+
+export type SupportedLanguage = keyof typeof SUPPORTED_LANGUAGES;
+
+const [locale, setLocale] = createSignal<SupportedLanguage>("en");
+
+function normalizeLanguage(language: string | null): SupportedLanguage {
+  return language === "zh-CN" ? "zh-CN" : "en";
+}
+
+export async function initI18n() {
+  const savedLanguage = normalizeLanguage(localStorage.getItem(LANGUAGE_STORAGE_KEY));
+
+  await i18next.init({
+    fallbackLng: "en",
+    interpolation: {
+      escapeValue: false,
+    },
+    lng: savedLanguage,
+    resources: {
+      en: { translation: en },
+      "zh-CN": { translation: zhCN },
+    },
+  });
+
+  setLocale(savedLanguage);
+}
+
+export function t(key: string, options?: TOptions) {
+  locale();
+  return i18next.t(key, options);
+}
+
+export async function changeLanguage(language: SupportedLanguage) {
+  await i18next.changeLanguage(language);
+  localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+  setLocale(language);
+}
+
+export function languageCodeToDisplay(language: SupportedLanguage) {
+  return SUPPORTED_LANGUAGES[language];
+}
+
+export function languageDisplayToCode(displayName: string): SupportedLanguage {
+  return displayName === SUPPORTED_LANGUAGES["zh-CN"] ? "zh-CN" : "en";
+}
+
+export { locale };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,68 @@
+{
+  "common": {
+    "cancel": "Cancel",
+    "remove": "Remove"
+  },
+  "topbar": {
+    "logoAlt": "fitgirl repack logo",
+    "gameHub": "GameHub",
+    "discovery": "Discovery",
+    "library": "Library",
+    "downloads": "Downloads",
+    "settings": "Settings",
+    "minimize": "Minimize",
+    "exitFullscreen": "Exit Fullscreen",
+    "restoreDown": "Restore Down",
+    "maximize": "Maximize",
+    "close": "Close",
+    "trayTitle": "FitLauncher is running in the tray",
+    "trayBody": "The app was minimized to the system tray. You can change this behavior in Settings.",
+    "installationInProgress": "Installation In Progress",
+    "installationExitWarning": "An installation is currently running. Closing will stop the installation.\n\nAre you sure you want to exit?",
+    "exitAnyway": "Exit Anyway"
+  },
+  "search": {
+    "placeholder": "Search Game...",
+    "failed": "Search failed",
+    "indexError": "Search index error"
+  },
+  "gamehub": {
+    "newlyAdded": "Newly Added Games",
+    "recentlyUpdated": "Recently Updated Games"
+  },
+  "settings": {
+    "title": "Settings",
+    "subtitle": "Configure your application preferences",
+    "invalidGroup": "Invalid group",
+    "globalConfiguration": "Global Configuration",
+    "downloadConfiguration": "Download Configuration",
+    "appSettings": "App Settings",
+    "dnsSettings": "DNS Settings",
+    "installSettings": "Install Settings",
+    "cacheAndLogs": "Cache & Logs",
+    "appInfo": "App Info",
+    "general": "General",
+    "transferLimits": "Transfer Limits",
+    "network": "Network",
+    "debridServices": "Debrid Services",
+    "bittorrent": "Bittorrent",
+    "aria2Rpc": "Aria2 RPC",
+    "display": {
+      "title": "Display Settings",
+      "language": "Language",
+      "languageDescription": "Choose the application language",
+      "hideNsfw": "Hide NSFW Content",
+      "hideNsfwDescription": "Hides any NSFW content everywhere except in downloaded games",
+      "comments": "Display comments on game pages",
+      "commentsDescription": "Allow to fetch and display comments on game pages from the community",
+      "closeToTray": "Close to Tray",
+      "closeToTrayDescription": "When closing, minimize to system tray instead of fully exiting",
+      "themes": "Change Themes",
+      "themesDescription": "Change themes as you want, you can even add your own!",
+      "backgroundImage": "Add Background Image",
+      "backgroundImageDescription": "Disabled for now, too unpredictable",
+      "backgroundBlur": "Change Background Blur",
+      "backgroundBlurDescription": "Only works when an image is chosen"
+    }
+  }
+}

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1,0 +1,68 @@
+{
+  "common": {
+    "cancel": "取消",
+    "remove": "移除"
+  },
+  "topbar": {
+    "logoAlt": "fitgirl repack 标志",
+    "gameHub": "游戏中心",
+    "discovery": "发现",
+    "library": "游戏库",
+    "downloads": "下载",
+    "settings": "设置",
+    "minimize": "最小化",
+    "exitFullscreen": "退出全屏",
+    "restoreDown": "还原窗口",
+    "maximize": "最大化",
+    "close": "关闭",
+    "trayTitle": "FitLauncher 正在托盘中运行",
+    "trayBody": "应用已最小化到系统托盘。你可以在设置中更改此行为。",
+    "installationInProgress": "安装正在进行",
+    "installationExitWarning": "当前有安装任务正在运行。关闭应用会停止安装。\n\n确定要退出吗？",
+    "exitAnyway": "仍然退出"
+  },
+  "search": {
+    "placeholder": "搜索游戏...",
+    "failed": "搜索失败",
+    "indexError": "搜索索引错误"
+  },
+  "gamehub": {
+    "newlyAdded": "新添加游戏",
+    "recentlyUpdated": "最近更新游戏"
+  },
+  "settings": {
+    "title": "设置",
+    "subtitle": "配置你的应用偏好",
+    "invalidGroup": "无效分组",
+    "globalConfiguration": "全局配置",
+    "downloadConfiguration": "下载配置",
+    "appSettings": "应用设置",
+    "dnsSettings": "DNS 设置",
+    "installSettings": "安装设置",
+    "cacheAndLogs": "缓存与日志",
+    "appInfo": "应用信息",
+    "general": "通用",
+    "transferLimits": "传输限制",
+    "network": "网络",
+    "debridServices": "Debrid 服务",
+    "bittorrent": "BitTorrent",
+    "aria2Rpc": "Aria2 RPC",
+    "display": {
+      "title": "显示设置",
+      "language": "语言",
+      "languageDescription": "选择应用界面语言",
+      "hideNsfw": "隐藏 NSFW 内容",
+      "hideNsfwDescription": "除已下载游戏外，在所有位置隐藏 NSFW 内容",
+      "comments": "在游戏页面显示评论",
+      "commentsDescription": "允许从社区获取并显示游戏页面评论",
+      "closeToTray": "关闭到托盘",
+      "closeToTrayDescription": "关闭窗口时最小化到系统托盘，而不是完全退出",
+      "themes": "切换主题",
+      "themesDescription": "按你的喜好切换主题，也可以添加自己的主题！",
+      "backgroundImage": "添加背景图片",
+      "backgroundImageDescription": "暂时禁用，此功能目前不够稳定",
+      "backgroundBlur": "调整背景模糊",
+      "backgroundBlurDescription": "仅在选择背景图片后生效"
+    }
+  }
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,12 +3,14 @@ import { render } from "solid-js/web";
 import "./styles.css";
 import App from "./App";
 import { DM } from "./api/manager/api";
+import { initI18n } from "./i18n";
 
 let savedTheme = localStorage.getItem("theme") || "blue-cyan";
 
 // Apply the saved theme to the document element
 document.documentElement.setAttribute("data-theme", savedTheme);
 
+await initI18n();
 await DM.setup();
 
 render(() => <App />, document.getElementById("root"));

--- a/src/pages/Gamehub-01/Gamehub-Components-01/Newly-Added-Games-01/Newly-Added-Games.tsx
+++ b/src/pages/Gamehub-01/Gamehub-Components-01/Newly-Added-Games-01/Newly-Added-Games.tsx
@@ -1,5 +1,6 @@
 import { createMemo, Show } from 'solid-js';
 import Slider from '../../../../components/Slider-01/Slider';
+import { t } from '../../../../i18n';
 import { useGamehub } from '../../GamehubContext';
 
 export default function NewlyAddedGames() {
@@ -15,7 +16,7 @@ export default function NewlyAddedGames() {
   return (
     <div class="flex flex-col h-fit pb-4">
       <div class="text-2xl text-text font-bold text-center pl-3">
-        <p>Newly Added Games</p>
+        <p>{t("gamehub.newlyAdded")}</p>
       </div>
       <Show when={filteredNewlyAdded().length > 0}>
         <Slider

--- a/src/pages/Gamehub-01/Gamehub-Components-01/Recently-Updated-Games-01/Recently-Updated-Games.tsx
+++ b/src/pages/Gamehub-01/Gamehub-Components-01/Recently-Updated-Games-01/Recently-Updated-Games.tsx
@@ -1,5 +1,6 @@
 import { createMemo, Show } from 'solid-js';
 import Slider from '../../../../components/Slider-01/Slider';
+import { t } from '../../../../i18n';
 import { useGamehub } from '../../GamehubContext';
 
 export default function RecentlyUpdatedGames() {
@@ -15,7 +16,7 @@ export default function RecentlyUpdatedGames() {
     return (
         <div class="flex flex-col h-fit pb-4">
             <div class="text-2xl font-bold text-text text-center pl-3">
-                <p>Recently Updated Games</p>
+                <p>{t("gamehub.recentlyUpdated")}</p>
             </div>
             <Show when={filteredRecentlyUpdated().length > 0}>
                 <Slider

--- a/src/pages/Settings-01/Settings-Categories/Global/DisplayPart/DisplayPart.tsx
+++ b/src/pages/Settings-01/Settings-Categories/Global/DisplayPart/DisplayPart.tsx
@@ -9,7 +9,10 @@ import LabelCheckboxSettings from "../../Components/UI/LabelCheckbox/LabelCheckb
 import LabelDropdownSettings from "../../Components/UI/LabelDropdown/LabelDropdown";
 import LabelButtonSettings from "../../Components/UI/LabelButton/LabelButton";
 import LabelRangeSettings from "../../Components/UI/LabelRange/LabelRange";
+import TitleLabel from "../../Components/UI/TitleLabel/TitleLabel";
+import Dropdown from "../../../../../components/UI/Dropdown/Dropdown";
 import { ThemeManagerApi } from "../../../../../api/theme/api";
+import { changeLanguage, languageCodeToDisplay, languageDisplayToCode, locale, SUPPORTED_LANGUAGES, t } from "../../../../../i18n";
 
 const themeAPI = new ThemeManagerApi();
 
@@ -48,28 +51,40 @@ export default function DisplayPart(props: SettingsSectionProps<GamehubSettings>
 
     return (
         <Show when={props.settings} fallback={<LoadingPage />}>
-            <PageGroup title="Display Settings">
+            <PageGroup title={t("settings.display.title")}>
+                <li class="flex items-center justify-between gap-4 bg-background-70 p-4 rounded-lg border border-secondary-20 hover:border-accent/30 transition-colors">
+                    <TitleLabel
+                        text={t("settings.display.language")}
+                        typeText={t("settings.display.languageDescription")}
+                    />
+                    <Dropdown
+                        list={Object.values(SUPPORTED_LANGUAGES)}
+                        activeItem={languageCodeToDisplay(locale())}
+                        onListChange={async (selected) => changeLanguage(languageDisplayToCode(selected))}
+                        placeholder={languageCodeToDisplay(locale())}
+                    />
+                </li>
                 <LabelCheckboxSettings
-                    text="Hide NSFW Content"
-                    typeText="Hides any NSFW content everywhere except in downloaded games"
+                    text={t("settings.display.hideNsfw")}
+                    typeText={t("settings.display.hideNsfwDescription")}
                     action={() => props.handleSwitchCheckChange?.("display.nsfw_censorship")}
                     checked={props.settings().nsfw_censorship}
                 />
                 <LabelCheckboxSettings
-                    text="Display comments on game pages"
-                    typeText="Allow to fetch and display comments on game pages from the community"
+                    text={t("settings.display.comments")}
+                    typeText={t("settings.display.commentsDescription")}
                     action={() => props.handleSwitchCheckChange?.("display.game_page_allow_comments")}
                     checked={props.settings().game_page_allow_comments}
                 />
                 <LabelCheckboxSettings
-                    text="Close to Tray"
-                    typeText="When closing, minimize to system tray instead of fully exiting"
+                    text={t("settings.display.closeToTray")}
+                    typeText={t("settings.display.closeToTrayDescription")}
                     action={() => props.handleSwitchCheckChange?.("display.close_to_tray")}
                     checked={props.settings().close_to_tray}
                 />
                 <LabelDropdownSettings
-                    text="Change Themes"
-                    typeText="Change themes as you want, you can even add your own!"
+                    text={t("settings.display.themes")}
+                    typeText={t("settings.display.themesDescription")}
                     list={[...defaultThemes, ...newThemes()]}
                     activeItem={currentTheme()}
                     onListChange={async (selected) => {
@@ -96,8 +111,8 @@ export default function DisplayPart(props: SettingsSectionProps<GamehubSettings>
                     }}
                 />
                 <LabelButtonSettings
-                    text="Add Background Image"
-                    typeText="Disabled for now, too unpredictable"
+                    text={t("settings.display.backgroundImage")}
+                    typeText={t("settings.display.backgroundImageDescription")}
                     action={async () => {
                         await themeAPI.chooseAndSetBackgroundImage(blurAmount());
                     }}
@@ -105,8 +120,8 @@ export default function DisplayPart(props: SettingsSectionProps<GamehubSettings>
                     disabled={true}
                 />
                 <LabelRangeSettings
-                    text="Change Background Blur"
-                    typeText="Only works when an image is chosen"
+                    text={t("settings.display.backgroundBlur")}
+                    typeText={t("settings.display.backgroundBlurDescription")}
                     min={0}
                     max={50}
                     value={blurAmount()}

--- a/src/pages/Settings-01/Settings.tsx
+++ b/src/pages/Settings-01/Settings.tsx
@@ -23,6 +23,7 @@ import type {
   SettingsGroup,
   DownloadSettingsPart
 } from "../../types/settings/types";
+import { t } from "../../i18n";
 import { SettingsProvider, useSettingsContext } from "./SettingsContext";
 
 function SettingsFull(): JSX.Element {
@@ -53,7 +54,7 @@ function SettingsContent(): JSX.Element {
 
   return (
     <div class="bg-popup-background border-l border-secondary-20 p-6 min-h-full shadow-lg">
-      {contentMap[activeGroup()]?.() ?? <p class="text-text">Invalid group</p>}
+      {contentMap[activeGroup()]?.() ?? <p class="text-text">{t("settings.invalidGroup")}</p>}
     </div>
   );
 }
@@ -93,31 +94,31 @@ function SettingsSidebar(): JSX.Element {
   return (
     <div class="bg-popup-background border-r border-secondary-20 h-full w-fit flex flex-col overflow-y-auto">
       <div class="p-4 border-b border-secondary-20">
-        <h1 class="text-2xl font-bold text-text">Settings</h1>
-        <p class="text-sm text-muted mt-1">Configure your application preferences</p>
+        <h1 class="text-2xl font-bold text-text">{t("settings.title")}</h1>
+        <p class="text-sm text-muted mt-1">{t("settings.subtitle")}</p>
       </div>
 
       <div class="flex flex-col gap-1 pr-2 py-4">
         <div class="mb-4">
-          <h2 class="text-xs font-semibold uppercase tracking-wider text-muted px-4 py-2">Global Configuration</h2>
+          <h2 class="text-xs font-semibold uppercase tracking-wider text-muted px-4 py-2">{t("settings.globalConfiguration")}</h2>
           <ul class="space-y-1">
-            <SidebarLink id="settings-display" label="App Settings" icon={Monitor} onClick={() => handleActivateElem("settings-display", "global-display")} />
-            <SidebarLink id="settings-dns" label="DNS Settings" icon={Network} onClick={() => handleActivateElem("settings-dns", "global-dns")} />
-            <SidebarLink id="settings-install" label="Install Settings" icon={HardDriveDownload} onClick={() => handleActivateElem("settings-install", "global-install")} />
-            <SidebarLink id="settings-cache" label="Cache & Logs" icon={Archive} onClick={() => handleActivateElem("settings-cache", "global-cache")} />
-            <SidebarLink id="settings-appinfo" label="App Info" icon={Info} onClick={() => handleActivateElem("settings-appinfo", "global-appinfo")} />
+            <SidebarLink id="settings-display" label={t("settings.appSettings")} icon={Monitor} onClick={() => handleActivateElem("settings-display", "global-display")} />
+            <SidebarLink id="settings-dns" label={t("settings.dnsSettings")} icon={Network} onClick={() => handleActivateElem("settings-dns", "global-dns")} />
+            <SidebarLink id="settings-install" label={t("settings.installSettings")} icon={HardDriveDownload} onClick={() => handleActivateElem("settings-install", "global-install")} />
+            <SidebarLink id="settings-cache" label={t("settings.cacheAndLogs")} icon={Archive} onClick={() => handleActivateElem("settings-cache", "global-cache")} />
+            <SidebarLink id="settings-appinfo" label={t("settings.appInfo")} icon={Info} onClick={() => handleActivateElem("settings-appinfo", "global-appinfo")} />
           </ul>
         </div>
 
         <div class="mb-4">
-          <h2 class="text-xs font-semibold uppercase tracking-wider text-muted px-4 py-2">Download Configuration</h2>
+          <h2 class="text-xs font-semibold uppercase tracking-wider text-muted px-4 py-2">{t("settings.downloadConfiguration")}</h2>
           <ul class="space-y-1">
-            <SidebarLink id="settings-general" label="General" icon={Settings} onClick={() => handleActivateElem("settings-general", "general")} />
-            <SidebarLink id="settings-limits" label="Transfer Limits" icon={Gauge} onClick={() => handleActivateElem("settings-limits", "limits")} />
-            <SidebarLink id="settings-network" label="Network" icon={Globe} onClick={() => handleActivateElem("settings-network", "network")} />
-            <SidebarLink id="settings-debrid" label="Debrid Services" icon={Zap} onClick={() => handleActivateElem("settings-debrid", "global-debrid")} />
-            <SidebarLink id="settings-bittorrent" label="Bittorrent" icon={Magnet} onClick={() => handleActivateElem("settings-bittorrent", "bittorrent")} />
-            <SidebarLink id="settings-rpc" label="Aria2 RPC" icon={Cpu} onClick={() => handleActivateElem("settings-rpc", "rpc")} />
+            <SidebarLink id="settings-general" label={t("settings.general")} icon={Settings} onClick={() => handleActivateElem("settings-general", "general")} />
+            <SidebarLink id="settings-limits" label={t("settings.transferLimits")} icon={Gauge} onClick={() => handleActivateElem("settings-limits", "limits")} />
+            <SidebarLink id="settings-network" label={t("settings.network")} icon={Globe} onClick={() => handleActivateElem("settings-network", "network")} />
+            <SidebarLink id="settings-debrid" label={t("settings.debridServices")} icon={Zap} onClick={() => handleActivateElem("settings-debrid", "global-debrid")} />
+            <SidebarLink id="settings-bittorrent" label={t("settings.bittorrent")} icon={Magnet} onClick={() => handleActivateElem("settings-bittorrent", "bittorrent")} />
+            <SidebarLink id="settings-rpc" label={t("settings.aria2Rpc")} icon={Cpu} onClick={() => handleActivateElem("settings-rpc", "rpc")} />
           </ul>
         </div>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,14 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
+    "moduleResolution": "Bundler",
     "strict": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "types": ["vite/client"]


### PR DESCRIPTION
## Summary
- Add i18next-based localization infrastructure with English and Simplified Chinese resources.
- Initialize i18n before app render and persist language choice in localStorage.
- Translate high-visibility Topbar, Settings sidebar, Display Settings, search placeholder, and Gamehub section headings, including a language selector.

## Test plan
- [x] npm install i18next
- [x] npx eslint src
- [x] npx tsc --noEmit
- [x] npm run build
- [x] npm run dev -- --host 127.0.0.1 and confirm the Vite server responds with HTTP 200
- [ ] Manual browser/Tauri UI click-through was not automated in this environment because no browser driver was available

🤖 Generated with [Claude Code](https://claude.com/claude-code)